### PR TITLE
Make latest version finder configurable

### DIFF
--- a/src/fileUtils/findLatestVersionPath.ts
+++ b/src/fileUtils/findLatestVersionPath.ts
@@ -1,14 +1,15 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import * as os from 'os';
 
 /**
- * Finds the latest version of the Manic Miners installation based on directory names with version numbers.
+ * Finds the latest version of the Manic Miners installation based on
+ * directory names with version numbers.
+ *
+ * @param baseDir The directory containing versioned installations.
  * @returns The full path to the executable of the latest version found.
  */
-export const findLatestVersionPath = async (): Promise<string> => {
-  const baseInstallationPath = path.join(os.homedir(), 'Desktop', 'map-generator-master', 'installations');
-  const directories = await fs.readdir(baseInstallationPath, { withFileTypes: true });
+export const findLatestVersionPath = async (baseDir: string): Promise<string> => {
+  const directories = await fs.readdir(baseDir, { withFileTypes: true });
   const versionedDirectories = directories
     .filter(dirent => dirent.isDirectory() && dirent.name.startsWith('ManicMinersV'))
     .map(dirent => dirent.name)
@@ -16,5 +17,5 @@ export const findLatestVersionPath = async (): Promise<string> => {
   const latestVersionDirectory = versionedDirectories[0];
   if (!latestVersionDirectory) throw new Error('No valid installation directory found.');
 
-  return path.join(baseInstallationPath, latestVersionDirectory, 'ManicMiners.exe');
+  return path.join(baseDir, latestVersionDirectory, 'ManicMiners.exe');
 };

--- a/src/functions/createDesktopShortcuts.ts
+++ b/src/functions/createDesktopShortcuts.ts
@@ -18,7 +18,8 @@ export const createDesktopShortcuts = async ({
 
   try {
     if (!installPath) {
-      installPath = await findLatestVersionPath();
+      const baseInstallDir = path.join(os.homedir(), 'Desktop', 'map-generator-master', 'installations');
+      installPath = await findLatestVersionPath(baseInstallDir);
     }
 
     const desktopPath = path.join(os.homedir(), 'Desktop');


### PR DESCRIPTION
## Summary
- pass installation directory into `findLatestVersionPath`
- update `createDesktopShortcuts` to supply the new directory

## Testing
- `npx prettier -w src/fileUtils/findLatestVersionPath.ts src/functions/createDesktopShortcuts.ts`
- `npx eslint src/fileUtils/findLatestVersionPath.ts src/functions/createDesktopShortcuts.ts` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_6865f82f856c8324b7273d922493453f