### PR TITLE
Add play sound IPC handler

### DIFF
--- a/src/main/ipcHandlers/setupPlaySoundHandler.ts
+++ b/src/main/ipcHandlers/setupPlaySoundHandler.ts
@@ -1,0 +1,34 @@
+import { ipcMain, app } from 'electron';
+import { IPC_CHANNELS } from './ipcChannels';
+import player from 'play-sound';
+import path from 'path';
+
+const soundPlayer = player();
+
+export const setupPlaySoundHandler = async (): Promise<{ status: boolean; message: string }> => {
+  let message = '';
+  let status = false;
+
+  try {
+    ipcMain.on(IPC_CHANNELS.PLAY_SOUND, () => {
+      try {
+        const soundPath = path.join(app.getAppPath(), 'assets', 'success.mp3');
+        soundPlayer.play(soundPath, (err: any) => {
+          if (err) {
+            console.error(`Failed to play sound: ${err.message}`);
+          }
+        });
+      } catch (err: any) {
+        console.error(`Failed to play sound: ${err.message}`);
+      }
+    });
+
+    message = 'Play sound handler set up successfully.';
+    status = true;
+  } catch (error: any) {
+    message = `Failed to set up play sound handler: ${error.message}`;
+    status = false;
+  }
+
+  return { status, message };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,6 +7,7 @@ import { setupDirectoryHandler } from './ipcHandlers/getDirectoriesIPC';
 import { setupInputPathDialog } from './ipcHandlers/setupInputPathDialog';
 import { setupUrlHandler } from './ipcHandlers/setupUrlHandler';
 import { setupLevelHandler } from './ipcHandlers/setupLevelHandler';
+import { setupPlaySoundHandler } from './ipcHandlers/setupPlaySoundHandler';
 
 const startApp = (): void => {
   app.on('ready', () => {
@@ -18,6 +19,7 @@ const startApp = (): void => {
     setupInputPathDialog();
     setupUrlHandler();
     setupLevelHandler();
+    setupPlaySoundHandler();
   });
 
   app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
- add a handler for `IPC_CHANNELS.PLAY_SOUND` that plays success.mp3
- hook the handler up in `main.ts`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run format` *(fails: unexpected closing tag in index.html)*
- `npx tsc -p tsconfig.json` *(fails to compile: cannot find modules and types)*

------
https://chatgpt.com/codex/tasks/task_b_6865f87bdee48324ac0efc7eaceb56d6