### PR TITLE
Conditionally open devtools

### DIFF
--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -19,5 +19,7 @@ export const createWindow = (): void => {
   });
 
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
-  mainWindow.webContents.openDevTools();
+  if (process.env.NODE_ENV === 'development') {
+    mainWindow.webContents.openDevTools();
+  }
 };


### PR DESCRIPTION
## Summary
- only open devtools when running in development mode

## Testing
- `npm run lint` *(fails: eslint-plugin-prettier missing)*

------
https://chatgpt.com/codex/tasks/task_b_6865f82f18648324819544f7509fae29