### PR TITLE
Secure IPC channel usage

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,11 +1,40 @@
 const { shell, contextBridge, ipcRenderer } = require('electron');
+const { IPC_CHANNELS } = require('../main/ipcHandlers/ipcChannels');
+
+const validSendChannels = [
+  IPC_CHANNELS.GET_DIRECTORIES,
+  IPC_CHANNELS.LAUNCH_GAME,
+  IPC_CHANNELS.DOWNLOAD_VERSION,
+  IPC_CHANNELS.PLAY_SOUND,
+  IPC_CHANNELS.ALL_VERSION_INFO,
+  IPC_CHANNELS.SET_SELECTED_VERSION,
+  IPC_CHANNELS.GET_URLS,
+  IPC_CHANNELS.GET_LEVELS,
+  'open-directory-dialog',
+];
+
+const validReceiveChannels = [
+  IPC_CHANNELS.GET_DIRECTORIES,
+  IPC_CHANNELS.LAUNCH_GAME,
+  IPC_CHANNELS.DOWNLOAD_PROGRESS,
+  IPC_CHANNELS.DOWNLOAD_VERSION,
+  IPC_CHANNELS.VERSIONS_UPDATED,
+  IPC_CHANNELS.ALL_VERSION_INFO,
+  IPC_CHANNELS.GET_URLS,
+  IPC_CHANNELS.GET_LEVELS,
+  'directory-selected',
+];
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  send: (channel: string, data: any) => {
-    ipcRenderer.send(channel, data);
+  send: (channel: string, data?: any) => {
+    if (validSendChannels.includes(channel)) {
+      ipcRenderer.send(channel, data);
+    }
   },
   receive: (channel: string, func: Function) => {
-    ipcRenderer.on(channel, (event, ...args) => func(...args));
+    if (validReceiveChannels.includes(channel)) {
+      ipcRenderer.on(channel, (_event, ...args) => func(...args));
+    }
   },
   openExternal: shell.openExternal,
 });


### PR DESCRIPTION
## Summary
- validate allowed channels in preload before using `ipcRenderer`
- only expose IPC channels used by the renderer

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run format` *(fails: SyntaxError in HTML file)*

------
https://chatgpt.com/codex/tasks/task_b_6865f82e443c832487b39127ecdf2062