### PR TITLE
Set up CI workflow with linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint
+      - name: Build Electron app
+        run: npm run make


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow
- install dependencies with npm and run lint
- attempt to build Electron app with `npm run make`

## Testing
- `npm run lint`
- `npm run make` *(fails: Cannot make for rpm, the following external binaries need to be installed: rpmbuild)*

------
https://chatgpt.com/codex/tasks/task_b_6866020b6600832481b51e972851e083