### PR TITLE
Add electron API types

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -5,3 +5,35 @@ declare module '*.partial_html' {
 }
 
 declare module 'play-sound';
+
+export type IpcChannel =
+  | 'launch-game'
+  | 'versions-updated'
+  | 'request-version-information'
+  | 'set-selected-version'
+  | 'get-selected-version'
+  | 'check-version-installed'
+  | 'select-install-directory'
+  | 'download-version'
+  | 'download-status'
+  | 'download-progress'
+  | 'get-directories'
+  | 'play-sound'
+  | 'get-urls'
+  | 'get-levels'
+  | 'open-directory-dialog'
+  | 'directory-selected';
+
+export interface ElectronAPI {
+  send: (channel: IpcChannel, data?: unknown) => void;
+  receive: (channel: IpcChannel, func: (...args: unknown[]) => void) => void;
+  openExternal: (url: string) => void;
+}
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+
+export {};

--- a/src/renderer/components/domUtils.ts
+++ b/src/renderer/components/domUtils.ts
@@ -8,10 +8,8 @@ export function trimFilePath(fullPath: string): string | null {
   return fullPath.substring(0, lastSlashIndex);
 }
 export function fetchDefaultDirectory(callback: (path: string) => void) {
-  //@ts-ignore
   window.electronAPI.send(IPC_CHANNELS.GET_DIRECTORIES);
 
-  //@ts-ignore
   window.electronAPI.receive(IPC_CHANNELS.GET_DIRECTORIES, response => {
     if (response.status && response.directories) {
       const installPathInput = document.getElementById('installPath') as HTMLInputElement;

--- a/src/renderer/components/initializeLevels.ts
+++ b/src/renderer/components/initializeLevels.ts
@@ -2,11 +2,9 @@
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 
 export const initializeLevels = (): void => {
-  //@ts-ignore
   window.electronAPI?.send(IPC_CHANNELS.GET_LEVELS);
 
   // Handler for receiving levels data
-  //@ts-ignore
   window.electronAPI?.receive(IPC_CHANNELS.GET_LEVELS, response => {
     if (response.status) {
       updateLevelsTable(response.levels); // Pass only the levels array

--- a/src/renderer/components/initializeUrls.ts
+++ b/src/renderer/components/initializeUrls.ts
@@ -2,11 +2,9 @@
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 
 export const initializeUrls = (): void => {
-  //@ts-ignore
   window.electronAPI?.send(IPC_CHANNELS.GET_URLS);
 
   // Handler for receiving URL data
-  //@ts-ignore
   window.electronAPI?.receive(IPC_CHANNELS.GET_URLS, response => {
     if (response.status) {
       updateLinksUI(response.urls); // Pass only the URLs object
@@ -38,7 +36,6 @@ export const initializeUrls = (): void => {
       link.innerHTML = `<i class="${getIconClass(key)}"></i>`;
       link.addEventListener('click', event => {
         event.preventDefault();
-        //@ts-ignore
         window.electronAPI.openExternal(url);
       });
       linksContainer.appendChild(link);
@@ -46,7 +43,7 @@ export const initializeUrls = (): void => {
   }
 
   function getIconClass(key: string) {
-    const iconMap = {
+    const iconMap: Record<string, string> = {
       Website: 'fas fa-globe',
       Discord: 'fab fa-discord',
       Reddit: 'fab fa-reddit-alien',
@@ -55,7 +52,6 @@ export const initializeUrls = (): void => {
       FAQ: 'fas fa-question-circle',
       Email: 'fas fa-envelope',
     };
-    //@ts-ignore
     const iconClass = iconMap[key] || 'fas fa-link';
     console.log(`Icon for ${key}: ${iconClass}`);
     return iconClass;

--- a/src/renderer/components/initializeVersionSelect.ts
+++ b/src/renderer/components/initializeVersionSelect.ts
@@ -6,19 +6,16 @@ export const initializeVersionSelect = (): void => {
   fetchVersionData();
 
   // Listener to refresh version information when updated
-  //@ts-ignore
   window.electronAPI?.receive(IPC_CHANNELS.VERSIONS_UPDATED, () => {
     fetchVersionData(); // Fetch the latest versions after update notifications
   });
 
   // Function to fetch version data
   function fetchVersionData() {
-    //@ts-ignore
     window.electronAPI?.send(IPC_CHANNELS.ALL_VERSION_INFO);
   }
 
   // Handler for receiving version information
-  //@ts-ignore
   window.electronAPI?.receive(IPC_CHANNELS.ALL_VERSION_INFO, data => {
     updateVersionSelectUI(data);
   });
@@ -50,7 +47,6 @@ export const initializeVersionSelect = (): void => {
     if (defaultVersion) {
       versionSelect.value = defaultVersion.identifier;
       setInstallPathAndToggleButton(defaultVersion, installPathInput);
-      //@ts-ignore
       window.electronAPI.send(IPC_CHANNELS.SET_SELECTED_VERSION, defaultVersion);
     } else {
       console.error('No default version provided.');
@@ -61,7 +57,6 @@ export const initializeVersionSelect = (): void => {
       const selectedIdentifier = versionSelect.value;
       const selectedVersion = versions.find((v: { identifier: string }) => v.identifier === selectedIdentifier);
       setInstallPathAndToggleButton(selectedVersion, installPathInput);
-      //@ts-ignore
       window.electronAPI.send(IPC_CHANNELS.SET_SELECTED_VERSION, selectedVersion);
     });
   }

--- a/src/renderer/components/setupDirectoryDialog.ts
+++ b/src/renderer/components/setupDirectoryDialog.ts
@@ -1,12 +1,10 @@
 export function setupDirectoryDialog(installPathInput: HTMLInputElement) {
   installPathInput.addEventListener('click', () => {
     // Trigger the directory dialog on click
-    //@ts-ignore
     window.electronAPI.send('open-directory-dialog');
   });
 
   // Handler to receive the selected directory path and update the input field
-  //@ts-ignore
   window.electronAPI.receive('directory-selected', path => {
     installPathInput.value = path;
   });

--- a/src/renderer/components/setupInstallButton.ts
+++ b/src/renderer/components/setupInstallButton.ts
@@ -19,25 +19,20 @@ export function setupInstallButton(installButton: HTMLButtonElement, installPath
     setDisabledAppearance(installPathInput, true);
 
     // Send the download request to the main process
-    //@ts-ignore
     window.electronAPI.send(IPC_CHANNELS.DOWNLOAD_VERSION, {
       version: versionIdentifier,
       downloadPath: downloadPath,
     });
   });
 
-  //@ts-ignore
   window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_PROGRESS, ({ progress, status }) => {
     updateStatus(progress, status);
   });
 
-  //@ts-ignore
   window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_VERSION, result => {
     console.log(result.message);
     if (result.downloaded) {
-      //@ts-ignore
       window.electronAPI.send(IPC_CHANNELS.PLAY_SOUND); // Request the main process to play the success sound
-      //@ts-ignore
       window.electronAPI.send(IPC_CHANNELS.ALL_VERSION_INFO); // Request updated version list
     } else {
       alert('Failed to download the version: ' + result.message);
@@ -49,10 +44,8 @@ export function setupInstallButton(installButton: HTMLButtonElement, installPath
     setDisabledAppearance(installPathInput, false);
   });
 
-  //@ts-ignore
   window.electronAPI.receive(IPC_CHANNELS.VERSIONS_UPDATED, () => {
     // Re-fetch version info to update the UI
-    //@ts-ignore
     window.electronAPI.send(IPC_CHANNELS.ALL_VERSION_INFO);
   });
 }

--- a/src/renderer/components/setupPlayButton.ts
+++ b/src/renderer/components/setupPlayButton.ts
@@ -16,12 +16,10 @@ export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HT
     setDisabledAppearance(installPathInput, true);
 
     // Send the version identifier to the main process to launch the game
-    //@ts-ignore
     window.electronAPI.send(IPC_CHANNELS.LAUNCH_GAME, versionIdentifier);
   });
 
   // Listen for game launch replies from the main process
-  //@ts-ignore
   window.electronAPI.receive(IPC_CHANNELS.LAUNCH_GAME, data => {
     console.log('Game launch status:', data);
 


### PR DESCRIPTION
## Summary
- define window.electronAPI types in `global.d.ts`
- clean up renderer code by removing `//@ts-ignore` lines

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'bootstrap', plus numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_b_686603936f688324b104976ecafa660f