### PR TITLE
Use ES modules in preload

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,5 +1,5 @@
-const { shell, contextBridge, ipcRenderer } = require('electron');
-const { IPC_CHANNELS } = require('../main/ipcHandlers/ipcChannels');
+import { shell, contextBridge, ipcRenderer } from 'electron';
+import { IPC_CHANNELS } from '../main/ipcHandlers/ipcChannels';
 
 const validSendChannels = [
   IPC_CHANNELS.GET_DIRECTORIES,


### PR DESCRIPTION
## Summary
- modernize the preload script to use ES module imports

## Testing
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_b_68660397a0a48324b403bf8ac6cc5368