### PR TITLE
Add cross-platform guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Welcome to the official repository of **Manic Miners Launcher**, a modern launcher for the nostalgic, classic game of building and mining. Our launcher aims to bring a renewed experience to fans of the original game, enhancing its accessibility and providing new features to the community.
 
 ## Features:
+
 - **Easy Installation**: Set up your game with just a few clicks. No more digging through forums for install guides.
 - **Auto-Updates**: Keep your game up to date with the latest patches and content without lifting a finger.
 - **Mod Support**: Easily manage and integrate mods to enhance your gameplay experience.
@@ -15,18 +16,22 @@ Welcome to the official repository of **Manic Miners Launcher**, a modern launch
 ## Getting Started:
 
 ### Prerequisites:
+
 Before you install the Manic Miners Launcher, ensure you have the following:
-- A PC running Windows 7 or later.
+
+- **Supported OS**: Windows 7 or later. Other operating systems are currently unsupported and some features will be disabled.
 - An internet connection for downloading the launcher and updates.
 - The original game files if you wish to apply mods or play certain versions.
 
 ### Installation:
+
 1. **Download the Launcher**: Navigate to the [Releases](https://github.com/Wal33D/manic-miners-launcher/releases) section of this GitHub repository and download the latest version of the launcher.
 2. **Run the Installer**: Open the downloaded file and follow the installation wizard. The installer will guide you through the process.
 3. **Launch the Game**: Once installed, open Manic Miners Launcher from your desktop or start menu. From here, you can manage your game settings, mods, or simply hit "Play" to dive in!
 
 ## Usage:
-After launching, you'll be presented with the main interface. 
+
+After launching, you'll be presented with the main interface.
 
 - **Update Your Game**: If there's an update available, you'll see a notification. Click "Update" to proceed.
 - **Manage Mods**: Navigate to the Mods section to browse and install mods. You can enable or disable mods for each profile.
@@ -34,12 +39,15 @@ After launching, you'll be presented with the main interface.
 - **Start Playing**: Once you're set, hit the "Play" button. Enjoy your journey in the mines!
 
 ## Support:
+
 Got questions or ran into issues? Visit our [Issues](https://github.com/Wal33D/manic-miners-launcher/issues) section to report bugs or seek help. Also, check out the [FAQs](https://github.com/Wal33D/manic-miners-launcher/wiki/FAQ) for common questions and answers.
 
 ## Contributing:
+
 We welcome contributions! Whether it's submitting bug reports, feature suggestions, or contributing to the code, check out our [Contributing Guidelines](CONTRIBUTING.md) for more information on getting involved.
 
 ## Development
+
 If you want to build the launcher from source you'll need **Node.js 18 or newer**.
 
 1. Install dependencies with `npm install` or `yarn`.
@@ -51,6 +59,7 @@ If you want to build the launcher from source you'll need **Node.js 18 or newer*
 Manic Miners Launcher is released under the [MIT License](LICENSE). See the LICENSE file for more details.
 
 ## Assets
+
 The bundled **Fredericka the Great** font is provided under the [SIL Open Font License](https://scripts.sil.org/OFL). See [assets/NOTICE](assets/NOTICE) for more information.
 
 Happy mining!

--- a/src/fileUtils/createShortcut.ts
+++ b/src/fileUtils/createShortcut.ts
@@ -18,6 +18,10 @@ export const createShortcut = async ({
   let created = false;
   let message = '';
 
+  if (process.platform !== 'win32') {
+    return { created: false, message: 'Shortcut creation is only supported on Windows.' };
+  }
+
   try {
     if (type === 'file' || type === 'directory') {
       // Handle file and directory shortcut creation

--- a/src/fileUtils/fileLock.ts
+++ b/src/fileUtils/fileLock.ts
@@ -3,7 +3,10 @@ import os from 'os';
 import path from 'path';
 import util from 'util';
 
-const lockFilePath = path.join(os.homedir(), 'AppData', 'LocalLow', 'ItchDownloadLock.lock');
+const lockFilePath =
+  process.platform === 'win32'
+    ? path.join(os.homedir(), 'AppData', 'LocalLow', 'ItchDownloadLock.lock')
+    : path.join(os.tmpdir(), 'ItchDownloadLock.lock');
 
 const fsWriteFile = util.promisify(fs.writeFile);
 const fsUnlink = util.promisify(fs.unlink);

--- a/src/functions/createDesktopShortcuts.ts
+++ b/src/functions/createDesktopShortcuts.ts
@@ -16,6 +16,11 @@ export const createDesktopShortcuts = async ({
   let status = true;
   const filePaths: string[] = [];
 
+  if (process.platform !== 'win32') {
+    console.warn('Shortcut creation is only supported on Windows.');
+    return { status: false, filePaths };
+  }
+
   try {
     if (!installPath) {
       const baseInstallDir = path.join(os.homedir(), 'Desktop', 'map-generator-master', 'installations');

--- a/src/functions/fetchDirectories.ts
+++ b/src/functions/fetchDirectories.ts
@@ -63,7 +63,7 @@ export async function getDirectories(): Promise<{ status: boolean; message: stri
     const savedBasePath = path.join(localAppData, 'ManicMiners', 'Saved');
     const logsPath = path.join(savedBasePath, 'Logs');
     const configPath = path.join(savedBasePath, 'Config');
-    const configIniPath = path.join(configPath, 'WindowsNoEditor');
+    const configIniPath = process.platform === 'win32' ? path.join(configPath, 'WindowsNoEditor') : configPath;
     const saveGamesPath = path.join(savedBasePath, 'SaveGames');
     const LRRPath = path.join(saveGamesPath, 'LRR');
     const profilesPath = path.join(saveGamesPath, 'Profiles');


### PR DESCRIPTION
## Summary
- avoid shortcut or lock creation on unsupported platforms
- handle config path on non-Windows systems
- document OS support in the README

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_b_6866039d00d48324ada3e8673268f785