### PR TITLE
Fix python executable detection

### DIFF
--- a/src/fileUtils/generateDatFile.ts
+++ b/src/fileUtils/generateDatFile.ts
@@ -13,7 +13,9 @@ export const generateDatFile = (params: MapGenerationParams | any): GenerateDatF
       return acc;
     }, [] as string[]);
 
-    const pythonProcess = spawnSync('python', [pythonScriptPath, ...args]);
+    const pythonExecutable = process.env.PYTHON_EXECUTABLE || process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
+
+    const pythonProcess = spawnSync(pythonExecutable, [pythonScriptPath, ...args]);
 
     if (pythonProcess.status === 1) {
       result = parseStructuredText(pythonProcess.stdout.toString());


### PR DESCRIPTION
## Summary
- detect python3 vs python using env var or platform
- run Prettier

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npx eslint .` *(fails: couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_686607798f148324bccc7db7adfab449