### PR TITLE
Fix stats.size comparison

### DIFF
--- a/src/functions/downloadFile.ts
+++ b/src/functions/downloadFile.ts
@@ -64,7 +64,7 @@ export async function downloadFile({
     });
 
     const stats = fs.statSync(filePath);
-    if (stats.size !== expectedSize) {
+    if (expectedSize !== undefined && stats.size !== expectedSize) {
       fs.unlinkSync(filePath);
       return {
         status: false,


### PR DESCRIPTION
## Summary
- handle missing expectedSize when verifying the downloaded file size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686607923ea08324a07c027fc112e852