### PR TITLE
Use log file for debug messages

### DIFF
--- a/src/functions/downloadVersion.ts
+++ b/src/functions/downloadVersion.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { verifyFile } from '../fileUtils/verifyFile';
 import { downloadFile } from './downloadFile';
 import { fetchVersions } from '../api/fetchVersions';
+import { debugLog } from '../logger';
 
 export const downloadVersion = async ({
   versionIdentifier,
@@ -20,7 +21,7 @@ export const downloadVersion = async ({
     const versions = versionData.versions; // Ensure this is an array
 
     updateStatus({ progress: 5 });
-    console.log('Available versions:', versions); // Debug: Log available versions
+    debugLog(`Available versions: ${JSON.stringify(versions)}`);
 
     if (!Array.isArray(versions)) {
       throw new Error('Fetched versions data is not an array');

--- a/src/functions/isVersionInstalled.ts
+++ b/src/functions/isVersionInstalled.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getDirectories } from './fetchDirectories';
+import { debugLog } from '../logger';
 
 /**
  * Checks if a specific version is installed by looking for its directory and executable.
@@ -16,7 +17,7 @@ export const isVersionInstalled = async (versionIdentifier: string): Promise<boo
     try {
       await fs.access(versionDirPath);
     } catch (error) {
-      console.log(`Version directory not found for ${versionIdentifier}:`, error);
+      debugLog(`Version directory not found for ${versionIdentifier}: ${error}`);
       return false; // Directory does not exist
     }
 
@@ -25,10 +26,10 @@ export const isVersionInstalled = async (versionIdentifier: string): Promise<boo
     const hasExecutable = filesInDir.some(file => file.endsWith('.exe'));
 
     if (hasExecutable) {
-      console.log(`Executable found in ${versionDirPath}.`);
+      debugLog(`Executable found in ${versionDirPath}.`);
       return true; // Installation is considered present if there's at least one executable
     } else {
-      console.log(`No executable found in ${versionDirPath}.`);
+      debugLog(`No executable found in ${versionDirPath}.`);
       return false; // Installation is considered absent without executables
     }
   } catch (error) {

--- a/src/functions/launchExecutable.ts
+++ b/src/functions/launchExecutable.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { logToFile } from '../logger';
+import { logToFile, debugLog } from '../logger';
 
 /**
  * Launches an executable file and monitors if it opened successfully or if it crashed.
@@ -24,7 +24,7 @@ export const launchExecutable = ({
     // Listen to stdout
     process.stdout.on('data', data => {
       const stdoutMessage = `stdout: ${data}`;
-      console.log(stdoutMessage);
+      debugLog(stdoutMessage);
       logToFile({ message: stdoutMessage });
     });
 
@@ -49,12 +49,12 @@ export const launchExecutable = ({
       const exitMessage =
         code === 0 ? 'Executable launched and exited normally.' : `Executable launched but exited with error code: ${code}`;
       const exitLogMessage = `Process exited at: ${new Date(endTime).toISOString()} (runtime: ${runTime.toFixed(2)} minutes)`;
-      console.log(exitLogMessage);
+      debugLog(exitLogMessage);
       logToFile({ message: exitLogMessage });
 
       if (veryShortRun) {
         const warningMessage = `Warning: The process had a very short run time (${runTime.toFixed(2)} minutes), which might indicate an issue.`;
-        console.warn(warningMessage);
+        debugLog(warningMessage);
         logToFile({ message: warningMessage });
       }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,9 @@ import fs from 'fs/promises'; // Use fs promises module for async file operation
 import { join } from 'path';
 import { getDirectories } from './functions/fetchDirectories';
 
+// Flag to control verbose logging
+export const isVerbose = process.env.VERBOSE === 'true';
+
 /**
  * Logs a message to a file with a timestamp. Uses a specified file or a default log file if no path is provided.
  * @param options An object containing the message and optional file path.
@@ -35,5 +38,15 @@ export const logToRuntimeLog = async ({ message }: { message: string }) => {
     await logToFile({ message, filePath: join(launcherLogsPath, 'runtime-log.txt') });
   } catch (error: any) {
     console.error(`Failed to log runtime message: ${error.message}`);
+  }
+};
+
+/**
+ * Logs a message to the runtime log only when verbose logging is enabled.
+ * @param message The debug message to log.
+ */
+export const debugLog = async (message: string) => {
+  if (isVerbose) {
+    await logToRuntimeLog({ message });
   }
 };

--- a/src/main/ipcHandlers/getDirectoriesIPC.ts
+++ b/src/main/ipcHandlers/getDirectoriesIPC.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { getDirectories } from '../../functions/fetchDirectories';
+import { debugLog } from '../../logger';
 
 export const setupDirectoryHandler = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
@@ -13,7 +14,7 @@ export const setupDirectoryHandler = async (): Promise<{ status: boolean; messag
         if (!dirResult.status) {
           throw new Error(dirResult.message);
         }
-        console.log('Sending directory data:', dirResult.directories);
+        debugLog(`Sending directory data: ${JSON.stringify(dirResult.directories)}`);
 
         event.reply(IPC_CHANNELS.GET_DIRECTORIES, {
           status: true,

--- a/src/main/ipcHandlers/setupDownloadHandlers.ts
+++ b/src/main/ipcHandlers/setupDownloadHandlers.ts
@@ -3,6 +3,7 @@ import { IPC_CHANNELS } from './ipcChannels';
 import { unpackVersion } from '../../functions/unpackVersion';
 import { downloadVersion } from '../../functions/downloadVersion';
 import { DownloadGameResponse, downloadGame } from 'itchio-downloader';
+import { debugLog } from '../../logger';
 import { fetchInstalledVersions } from '../../functions/fetchInstalledVersions';
 import Store from 'electron-store';
 
@@ -14,7 +15,7 @@ export const setupDownloadHandlers = async (): Promise<{ status: boolean; messag
 
   try {
     ipcMain.on(IPC_CHANNELS.DOWNLOAD_VERSION, async (event, { version, downloadPath }) => {
-      console.log(`Downloading version: ${version} to ${downloadPath}`);
+      debugLog(`Downloading version: ${version} to ${downloadPath}`);
       //latest version only do this for a download instead -->
       const { filePath, metaData, metadataPath, message, status } = (await downloadGame({
         itchGameUrl: 'https://baraklava.itch.io/manic-miners',
@@ -22,7 +23,7 @@ export const setupDownloadHandlers = async (): Promise<{ status: boolean; messag
       })) as DownloadGameResponse;
       //<-- latest version only do this for a download instead
 
-      console.log(filePath, metaData, metadataPath, message, status);
+      debugLog(`${filePath} ${metaData} ${metadataPath} ${message} ${status}`);
       try {
         const downloadResult = await downloadVersion({
           versionIdentifier: version,

--- a/src/main/ipcHandlers/setupGameLaunchHandlers.ts
+++ b/src/main/ipcHandlers/setupGameLaunchHandlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { handleGameLaunch } from '../../functions/handleGameLaunch';
+import { debugLog } from '../../logger';
 
 export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
@@ -8,7 +9,7 @@ export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; mess
 
   try {
     ipcMain.on(IPC_CHANNELS.LAUNCH_GAME, async (event, versionIdentifier) => {
-      console.log(`Launching game with version: ${versionIdentifier}`);
+      debugLog(`Launching game with version: ${versionIdentifier}`);
       try {
         const success = await handleGameLaunch({ versionIdentifier });
         event.reply(IPC_CHANNELS.LAUNCH_GAME, {

--- a/src/main/ipcHandlers/setupLatestDownloadHandler.ts
+++ b/src/main/ipcHandlers/setupLatestDownloadHandler.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { unpackVersion } from '../../functions/unpackVersion';
 import { downloadGame } from 'itchio-downloader';
+import { debugLog } from '../../logger';
 
 export const setupLatestDownloadHandler = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
@@ -18,7 +19,7 @@ export const setupLatestDownloadHandler = async (): Promise<{ status: boolean; m
         return;
       }
 
-      console.log(`Downloading the latest version to ${downloadPath}`);
+      debugLog(`Downloading the latest version to ${downloadPath}`);
 
       const downloadResponse = (await downloadGame({
         itchGameUrl: 'https://baraklava.itch.io/manic-miners',
@@ -27,7 +28,7 @@ export const setupLatestDownloadHandler = async (): Promise<{ status: boolean; m
 
       const { filePath, metaData, metadataPath, message, status } = downloadResponse;
 
-      console.log(filePath, metaData, metadataPath, message, status);
+      debugLog(`${filePath} ${metaData} ${metadataPath} ${message} ${status}`);
 
       if (!status) {
         event.reply(IPC_CHANNELS.DOWNLOAD_VERSION, {

--- a/src/main/ipcHandlers/setupLevelHandler.ts
+++ b/src/main/ipcHandlers/setupLevelHandler.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { fetchLevels } from '../../api/fetchLevels';
+import { debugLog } from '../../logger';
 
 export const setupLevelHandler = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
@@ -10,7 +11,7 @@ export const setupLevelHandler = async (): Promise<{ status: boolean; message: s
     ipcMain.on(IPC_CHANNELS.GET_LEVELS, async event => {
       try {
         const levelsResult = await fetchLevels();
-        console.log('Sending level data:', levelsResult);
+        debugLog(`Sending level data: ${JSON.stringify(levelsResult)}`);
 
         event.reply(IPC_CHANNELS.GET_LEVELS, {
           status: true,

--- a/src/main/ipcHandlers/setupUrlHandler.ts
+++ b/src/main/ipcHandlers/setupUrlHandler.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { fetchUrls } from '../../api/fetchUrls';
+import { debugLog } from '../../logger';
 
 export const setupUrlHandler = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
@@ -10,7 +11,7 @@ export const setupUrlHandler = async (): Promise<{ status: boolean; message: str
     ipcMain.on(IPC_CHANNELS.GET_URLS, async event => {
       try {
         const urlResult = await fetchUrls();
-        console.log('Sending URL data:', urlResult);
+        debugLog(`Sending URL data: ${JSON.stringify(urlResult)}`);
 
         event.reply(IPC_CHANNELS.GET_URLS, {
           status: true,

--- a/src/main/ipcHandlers/setupVersionHandlers.ts
+++ b/src/main/ipcHandlers/setupVersionHandlers.ts
@@ -4,6 +4,7 @@ import { IPC_CHANNELS } from './ipcChannels';
 import { fetchVersions } from '../../api/fetchVersions';
 import { fetchInstalledVersions } from '../../functions/fetchInstalledVersions';
 import Store from 'electron-store';
+import { debugLog } from '../../logger';
 const store = new Store() as any;
 
 export const setupVersionHandlers = () => {
@@ -53,11 +54,11 @@ const getVersionDetails = async () => {
 
 const setSelectedVersion = (selectedVersion: Version) => {
   store.set('current-selected-version', selectedVersion);
-  console.log(`Selected version updated: ${selectedVersion.identifier}`);
+  debugLog(`Selected version updated: ${selectedVersion.identifier}`);
 };
 
 const getSelectedVersion = () => {
   const selectedVersion = store.get('current-selected-version');
-  console.log(`Currently selected version: ${selectedVersion.identifier}`);
+  debugLog(`Currently selected version: ${selectedVersion.identifier}`);
   return selectedVersion;
 };

--- a/src/renderer/components/domUtils.ts
+++ b/src/renderer/components/domUtils.ts
@@ -1,4 +1,5 @@
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
+import { debugLog } from '../../logger';
 
 export function trimFilePath(fullPath: string): string | null {
   if (!fullPath || fullPath.lastIndexOf('\\') === -1) {
@@ -16,7 +17,7 @@ export function fetchDefaultDirectory(callback: (path: string) => void) {
       // Assuming 'response.directories' contains the actual directory data
       installPathInput.value = response.directories.launcherInstallPath;
       callback(response.directories.launcherInstallPath); // Call the callback with the path
-      console.log('Directory received and set: ', response.directories.launcherInstallPath);
+      debugLog(`Directory received and set: ${response.directories.launcherInstallPath}`);
     } else {
       console.error('Failed to fetch directories:', response.message);
       // Optionally set a default or handle error case

--- a/src/renderer/components/initializeLevels.ts
+++ b/src/renderer/components/initializeLevels.ts
@@ -1,5 +1,6 @@
 // Import IPC channels from a centralized file (adjust the import path as needed)
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
+import { debugLog } from '../../logger';
 
 export const initializeLevels = (): void => {
   window.electronAPI?.send(IPC_CHANNELS.GET_LEVELS);
@@ -8,7 +9,7 @@ export const initializeLevels = (): void => {
   window.electronAPI?.receive(IPC_CHANNELS.GET_LEVELS, response => {
     if (response.status) {
       updateLevelsTable(response.levels); // Pass only the levels array
-      console.log('Received levels:', response.levels);
+      debugLog(`Received levels: ${JSON.stringify(response.levels)}`);
     } else {
       console.error('Failed to fetch levels:', response.message);
     }

--- a/src/renderer/components/initializeUrls.ts
+++ b/src/renderer/components/initializeUrls.ts
@@ -1,5 +1,6 @@
 // Import IPC channels from a centralized file (adjust the import path as needed)
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
+import { debugLog } from '../../logger';
 
 export const initializeUrls = (): void => {
   window.electronAPI?.send(IPC_CHANNELS.GET_URLS);
@@ -8,7 +9,7 @@ export const initializeUrls = (): void => {
   window.electronAPI?.receive(IPC_CHANNELS.GET_URLS, response => {
     if (response.status) {
       updateLinksUI(response.urls); // Pass only the URLs object
-      console.log('Received URLs:', response.urls);
+      debugLog(`Received URLs: ${JSON.stringify(response.urls)}`);
     } else {
       console.error('Failed to fetch URLs:', response.message);
     }
@@ -29,7 +30,7 @@ export const initializeUrls = (): void => {
 
     // Correctly access each URL and associated key
     Object.entries(urls).forEach(([key, url]) => {
-      console.log(`URL for ${key}: ${url}`); // Debugging output
+      debugLog(`URL for ${key}: ${url}`);
       const link = document.createElement('a');
       link.setAttribute('data-url', url as string);
       link.className = 'not-draggable icon-button';
@@ -53,7 +54,7 @@ export const initializeUrls = (): void => {
       Email: 'fas fa-envelope',
     };
     const iconClass = iconMap[key] || 'fas fa-link';
-    console.log(`Icon for ${key}: ${iconClass}`);
+    debugLog(`Icon for ${key}: ${iconClass}`);
     return iconClass;
   }
 };

--- a/src/renderer/components/setupInstallButton.ts
+++ b/src/renderer/components/setupInstallButton.ts
@@ -2,6 +2,7 @@
 import { updateStatus } from './updateStatus';
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { setDisabledAppearance } from './domUtils';
+import { debugLog } from '../../logger';
 
 export function setupInstallButton(installButton: HTMLButtonElement, installPathInput: HTMLInputElement, versionSelect: HTMLSelectElement) {
   installButton.addEventListener('click', () => {
@@ -30,7 +31,7 @@ export function setupInstallButton(installButton: HTMLButtonElement, installPath
   });
 
   window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_VERSION, result => {
-    console.log(result.message);
+    debugLog(result.message);
     if (result.downloaded) {
       window.electronAPI.send(IPC_CHANNELS.PLAY_SOUND); // Request the main process to play the success sound
       window.electronAPI.send(IPC_CHANNELS.ALL_VERSION_INFO); // Request updated version list

--- a/src/renderer/components/setupPlayButton.ts
+++ b/src/renderer/components/setupPlayButton.ts
@@ -1,6 +1,7 @@
 // playButtonHandler.ts
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { setDisabledAppearance } from './domUtils';
+import { debugLog } from '../../logger';
 
 export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HTMLSelectElement, installPathInput: HTMLInputElement) {
   playButton.addEventListener('click', () => {
@@ -21,7 +22,7 @@ export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HT
 
   // Listen for game launch replies from the main process
   window.electronAPI.receive(IPC_CHANNELS.LAUNCH_GAME, data => {
-    console.log('Game launch status:', data);
+    debugLog(`Game launch status: ${JSON.stringify(data)}`);
 
     // Re-enable play button, version select dropdown, and install path input after receiving the launch status
     setDisabledAppearance(playButton, false);
@@ -29,7 +30,7 @@ export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HT
     setDisabledAppearance(installPathInput, false);
 
     if (data.success) {
-      console.log('Game launched successfully');
+      debugLog('Game launched successfully');
     } else {
       console.error('Failed to launch game:', data.message);
     }


### PR DESCRIPTION
## Summary
- introduce a `debugLog` helper in `logger.ts`
- gate verbose logging behind `VERBOSE` env variable
- replace `console.log` calls with `debugLog`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npx tsc --noEmit` *(fails: multiple missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6866078431bc8324b4d1f4acb66e9b6d