### PR TITLE
Add tests for verifyFile and run all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .ts,.tsx .",
     "format": "prettier --write .",
     "update-git-url": "node updatePackageJson.js",
-    "test": "node --require ts-node/register --test test/downloadFile.test.ts"
+    "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.4.0",

--- a/test/verifyFile.test.ts
+++ b/test/verifyFile.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import { verifyFile } from '../src/fileUtils/verifyFile';
+
+// helper to create temporary directory and file
+function createTempFile(content: string): { dir: string; file: string; size: number } {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'file.txt');
+  fs.writeFileSync(file, content);
+  const size = fs.statSync(file).size;
+  return { dir, file, size };
+}
+
+test('verifyFile detects existing file with matching size', async () => {
+  const { dir, file, size } = createTempFile('hello');
+
+  const info = await verifyFile({ filePath: file, expectedSize: size });
+
+  assert.strictEqual(info.exists, true);
+  assert.strictEqual(info.size, size);
+  assert.strictEqual(info.sizeMatches, true);
+  assert.strictEqual(info.isFile, true);
+  assert.strictEqual(info.isDirectory, false);
+  assert.strictEqual(info.name, 'file.txt');
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('verifyFile identifies size mismatch', async () => {
+  const { dir, file } = createTempFile('abc');
+
+  const info = await verifyFile({ filePath: file, expectedSize: 10 });
+
+  assert.strictEqual(info.exists, true);
+  assert.strictEqual(info.sizeMatches, false);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('verifyFile handles missing file', async () => {
+  const missing = path.join(process.cwd(), 'nonexistent-file.txt');
+
+  const info = await verifyFile({ filePath: missing });
+
+  assert.strictEqual(info.exists, false);
+  assert.strictEqual(info.isFile, false);
+});


### PR DESCRIPTION
## Summary
- expand test script to run all `.test.ts` files
- add unit tests for `verifyFile`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866091a1d308324aa28e31f8c07f79d