### PR TITLE
Fix build issues and update typings

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,10 @@
-import fs from 'fs/promises'; // Use fs promises module for async file operations
-import { join } from 'path';
-import { getDirectories } from './functions/fetchDirectories';
+let fs: typeof import('fs/promises') | null = null;
+let join: ((...paths: string[]) => string) | null = null;
+
+if (typeof process !== 'undefined' && process.type !== 'renderer') {
+  fs = eval('require')("fs").promises;
+  ({ join } = eval('require')("path"));
+}
 
 // Flag to control verbose logging
 export const isVerbose = process.env.VERBOSE === 'true';
@@ -10,7 +14,12 @@ export const isVerbose = process.env.VERBOSE === 'true';
  * @param options An object containing the message and optional file path.
  */
 export const logToFile = async ({ message, filePath }: { message: string; filePath?: string }) => {
+  if (!fs || !join) {
+    console.log(message);
+    return;
+  }
   try {
+    const { getDirectories } = eval('require')("./functions/fetchDirectories");
     const { status, message: dirMessage, directories } = await getDirectories();
     if (!status) {
       throw new Error(dirMessage);
@@ -29,7 +38,12 @@ export const logToFile = async ({ message, filePath }: { message: string; filePa
  * @param message The message to log.
  */
 export const logToRuntimeLog = async ({ message }: { message: string }) => {
+  if (!fs || !join) {
+    console.log(message);
+    return;
+  }
   try {
+    const { getDirectories } = eval('require')("./functions/fetchDirectories");
     const { status, message: dirMessage, directories } = await getDirectories();
     if (!status) {
       throw new Error(dirMessage);

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -13,4 +13,4 @@ export const IPC_CHANNELS = {
   PLAY_SOUND: 'play-sound',
   GET_URLS: 'get-urls',
   GET_LEVELS: 'get-levels',
-};
+} as const;

--- a/src/main/ipcHandlers/setupDownloadHandlers.ts
+++ b/src/main/ipcHandlers/setupDownloadHandlers.ts
@@ -19,7 +19,7 @@ export const setupDownloadHandlers = async (): Promise<{ status: boolean; messag
       //latest version only do this for a download instead -->
       const { filePath, metaData, metadataPath, message, status } = (await downloadGame({
         itchGameUrl: 'https://baraklava.itch.io/manic-miners',
-        desiredFileDirectory: downloadPath,
+        downloadDirectory: downloadPath,
       })) as DownloadGameResponse;
       //<-- latest version only do this for a download instead
 

--- a/src/main/ipcHandlers/setupLatestDownloadHandler.ts
+++ b/src/main/ipcHandlers/setupLatestDownloadHandler.ts
@@ -23,7 +23,7 @@ export const setupLatestDownloadHandler = async (): Promise<{ status: boolean; m
 
       const downloadResponse = (await downloadGame({
         itchGameUrl: 'https://baraklava.itch.io/manic-miners',
-        desiredFileDirectory: downloadPath,
+        downloadDirectory: downloadPath,
       })) as any;
 
       const { filePath, metaData, metadataPath, message, status } = downloadResponse;

--- a/src/renderer/components/domUtils.ts
+++ b/src/renderer/components/domUtils.ts
@@ -11,7 +11,7 @@ export function trimFilePath(fullPath: string): string | null {
 export function fetchDefaultDirectory(callback: (path: string) => void) {
   window.electronAPI.send(IPC_CHANNELS.GET_DIRECTORIES);
 
-  window.electronAPI.receive(IPC_CHANNELS.GET_DIRECTORIES, response => {
+  window.electronAPI.receive(IPC_CHANNELS.GET_DIRECTORIES, (response: any) => {
     if (response.status && response.directories) {
       const installPathInput = document.getElementById('installPath') as HTMLInputElement;
       // Assuming 'response.directories' contains the actual directory data

--- a/src/renderer/components/initializeLevels.ts
+++ b/src/renderer/components/initializeLevels.ts
@@ -6,7 +6,7 @@ export const initializeLevels = (): void => {
   window.electronAPI?.send(IPC_CHANNELS.GET_LEVELS);
 
   // Handler for receiving levels data
-  window.electronAPI?.receive(IPC_CHANNELS.GET_LEVELS, response => {
+  window.electronAPI?.receive(IPC_CHANNELS.GET_LEVELS, (response: any) => {
     if (response.status) {
       updateLevelsTable(response.levels); // Pass only the levels array
       debugLog(`Received levels: ${JSON.stringify(response.levels)}`);

--- a/src/renderer/components/initializeUrls.ts
+++ b/src/renderer/components/initializeUrls.ts
@@ -6,7 +6,7 @@ export const initializeUrls = (): void => {
   window.electronAPI?.send(IPC_CHANNELS.GET_URLS);
 
   // Handler for receiving URL data
-  window.electronAPI?.receive(IPC_CHANNELS.GET_URLS, response => {
+  window.electronAPI?.receive(IPC_CHANNELS.GET_URLS, (response: any) => {
     if (response.status) {
       updateLinksUI(response.urls); // Pass only the URLs object
       debugLog(`Received URLs: ${JSON.stringify(response.urls)}`);
@@ -37,7 +37,7 @@ export const initializeUrls = (): void => {
       link.innerHTML = `<i class="${getIconClass(key)}"></i>`;
       link.addEventListener('click', event => {
         event.preventDefault();
-        window.electronAPI.openExternal(url);
+        window.electronAPI.openExternal(url as string);
       });
       linksContainer.appendChild(link);
     });

--- a/src/renderer/components/initializeVersionSelect.ts
+++ b/src/renderer/components/initializeVersionSelect.ts
@@ -16,7 +16,7 @@ export const initializeVersionSelect = (): void => {
   }
 
   // Handler for receiving version information
-  window.electronAPI?.receive(IPC_CHANNELS.ALL_VERSION_INFO, data => {
+  window.electronAPI?.receive(IPC_CHANNELS.ALL_VERSION_INFO, (data: any) => {
     updateVersionSelectUI(data);
   });
 

--- a/src/renderer/components/setupDirectoryDialog.ts
+++ b/src/renderer/components/setupDirectoryDialog.ts
@@ -5,7 +5,7 @@ export function setupDirectoryDialog(installPathInput: HTMLInputElement) {
   });
 
   // Handler to receive the selected directory path and update the input field
-  window.electronAPI.receive('directory-selected', path => {
-    installPathInput.value = path;
+  window.electronAPI.receive('directory-selected', (path: any) => {
+    installPathInput.value = path as string;
   });
 }

--- a/src/renderer/components/setupInstallButton.ts
+++ b/src/renderer/components/setupInstallButton.ts
@@ -30,7 +30,7 @@ export function setupInstallButton(installButton: HTMLButtonElement, installPath
     updateStatus(progress, status);
   });
 
-  window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_VERSION, result => {
+  window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_VERSION, (result: any) => {
     debugLog(result.message);
     if (result.downloaded) {
       window.electronAPI.send(IPC_CHANNELS.PLAY_SOUND); // Request the main process to play the success sound

--- a/src/renderer/components/setupPlayButton.ts
+++ b/src/renderer/components/setupPlayButton.ts
@@ -21,7 +21,7 @@ export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HT
   });
 
   // Listen for game launch replies from the main process
-  window.electronAPI.receive(IPC_CHANNELS.LAUNCH_GAME, data => {
+  window.electronAPI.receive(IPC_CHANNELS.LAUNCH_GAME, (data: any) => {
     debugLog(`Game launch status: ${JSON.stringify(data)}`);
 
     // Re-enable play button, version select dropdown, and install path input after receiving the launch status

--- a/src/types/play-sound.d.ts
+++ b/src/types/play-sound.d.ts
@@ -1,0 +1,1 @@
+declare module 'play-sound';


### PR DESCRIPTION
## Summary
- update IPC channels constant typing
- fix download handlers to use correct `downloadDirectory` option
- create play-sound module declaration
- add runtime checks in logger to avoid bundling Node modules
- cast IPC responses to `any` in renderer code

## Testing
- `npm test`
- `npm run start` *(fails to run Electron in root but webpack builds and dev server launches)*

------
https://chatgpt.com/codex/tasks/task_b_68660f471a0883249d71fde3d72e604c