### PR TITLE
Fix EPIPE startup crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A dedicated launcher for Manic Miners, an adventurous underground mining game that pays homage to classic resource management and strategy games.",
   "main": ".webpack/main",
   "scripts": {
-    "start": "electron-forge start",
+    "start": "electron-forge start -- --no-sandbox",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",


### PR DESCRIPTION
## Summary
- disable Electron sandbox when launching so the app runs in root environments

## Testing
- `npm test`
- `npm run start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_b_6866120caaec832480d7b2df60ce32a0