### PR TITLE
Disable nodeIntegration in Electron window

### DIFF
--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -11,7 +11,7 @@ export const createWindow = (): void => {
     minHeight: 600, // Minimum height of the window
     webPreferences: {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
-      nodeIntegration: true,
+      nodeIntegration: false,
       contextIsolation: true,
     },
     autoHideMenuBar: true, // This will hide the menu bar


### PR DESCRIPTION
## Summary
- improve security by disabling `nodeIntegration`
- keep all communication restricted to the preload bridge API

## Testing
- `npm test`
- `npm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_b_68661e1232c08324bc756c70197b72ef