### PR TITLE
Remove eval usage in logger

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,10 @@
 let fs: typeof import('fs/promises') | null = null;
 let join: ((...paths: string[]) => string) | null = null;
 
-if (typeof process !== 'undefined' && process.type !== 'renderer') {
-  fs = eval('require')("fs").promises;
-  ({ join } = eval('require')("path"));
+if (typeof process !== 'undefined' && (process as any).type !== 'renderer') {
+  // Directly require Node modules when running outside the renderer
+  fs = require('fs').promises;
+  ({ join } = require('path'));
 }
 
 // Flag to control verbose logging
@@ -19,7 +20,7 @@ export const logToFile = async ({ message, filePath }: { message: string; filePa
     return;
   }
   try {
-    const { getDirectories } = eval('require')("./functions/fetchDirectories");
+    const { getDirectories } = await import('./functions/fetchDirectories');
     const { status, message: dirMessage, directories } = await getDirectories();
     if (!status) {
       throw new Error(dirMessage);
@@ -43,7 +44,7 @@ export const logToRuntimeLog = async ({ message }: { message: string }) => {
     return;
   }
   try {
-    const { getDirectories } = eval('require')("./functions/fetchDirectories");
+    const { getDirectories } = await import('./functions/fetchDirectories');
     const { status, message: dirMessage, directories } = await getDirectories();
     if (!status) {
       throw new Error(dirMessage);

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+
+function loadLogger() {
+  const loggerPath = path.resolve(__dirname, '../src/logger');
+  delete require.cache[require.resolve(loggerPath)];
+  return require(loggerPath);
+}
+
+test('logToFile writes to file when not in renderer', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'log.txt');
+
+  const originalType = (process as any).type;
+  delete (process as any).type;
+  const logger = loadLogger();
+  await logger.logToFile({ message: 'hello world', filePath: file });
+
+  assert.ok(fs.existsSync(file));
+  const content = fs.readFileSync(file, 'utf-8');
+  assert.match(content, /hello world/);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  if (originalType === undefined) {
+    delete (process as any).type;
+  } else {
+    (process as any).type = originalType;
+  }
+});
+
+test('logToFile falls back to console in renderer', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'log.txt');
+
+  const originalType = (process as any).type;
+  (process as any).type = 'renderer';
+  const logger = loadLogger();
+  await logger.logToFile({ message: 'should not write', filePath: file });
+
+  assert.ok(!fs.existsSync(file));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  if (originalType === undefined) {
+    delete (process as any).type;
+  } else {
+    (process as any).type = originalType;
+  }
+});
+


### PR DESCRIPTION
## Summary
- remove `eval('require')` calls from the logger
- dynamically import `fetchDirectories`
- add tests for logging behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68661e2dbab883249fef1add059b79a2