### PR TITLE
Make server base URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ If you want to build the launcher from source you'll need **Node.js 20 or newer*
 2. Start the app in development mode using `npm run start`.
 3. To create distributable packages run `npm run make`.
 
+### Environment Variables
+
+`SERVER_BASE_URL` sets the base URL used for update checks and other API calls.
+If not provided, the launcher defaults to `https://manic-launcher.vercel.app`.
+Set this variable before running the app if you need to target a different
+server.
+
 ## License:
 
 Manic Miners Launcher is released under the [MIT License](LICENSE). See the LICENSE file for more details.

--- a/src/api/fetchServerData.ts
+++ b/src/api/fetchServerData.ts
@@ -4,6 +4,9 @@ import { getDirectories } from '../functions/fetchDirectories';
 import fetch from 'node-fetch';
 import { fetchServerEndpoints } from './fetchServerEndpoints';
 
+const SERVER_BASE_URL = process.env.SERVER_BASE_URL ||
+  'https://manic-launcher.vercel.app';
+
 interface FetchResult {
   status: boolean;
   data?: any;
@@ -47,7 +50,7 @@ export async function fetchServerData({ routeName = 'launcher.all' }: { routeNam
 
     // Fetch data from the selected endpoint
     const endpoint = endpointResult.data; // Safely extracted single endpoint data
-    const response = await fetch(`https://manic-launcher.vercel.app${endpoint.endpoint}`);
+    const response = await fetch(`${SERVER_BASE_URL}${endpoint.endpoint}`);
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);
     }

--- a/src/api/fetchServerEndpoints.ts
+++ b/src/api/fetchServerEndpoints.ts
@@ -3,6 +3,9 @@ import { promises as fs } from 'fs';
 import { getDirectories } from '../functions/fetchDirectories';
 import { default as fetch } from 'node-fetch';
 
+const SERVER_BASE_URL = process.env.SERVER_BASE_URL ||
+  'https://manic-launcher.vercel.app';
+
 interface Endpoint {
   name: string;
   endpoint: string;
@@ -39,7 +42,7 @@ export async function fetchServerEndpoints({
       data = JSON.parse(cachedData);
     } catch (error) {
       // If reading fails or cache is expired, fetch from API and cache the result
-      const routesResponse = await fetch('https://manic-launcher.vercel.app/api/routes');
+      const routesResponse = await fetch(`${SERVER_BASE_URL}/api/routes`);
       if (!routesResponse.ok) {
         throw new Error(`Failed to fetch endpoints. Status: ${routesResponse.status}`);
       }


### PR DESCRIPTION
## Summary
- allow overriding the backend server URL via `SERVER_BASE_URL`
- update API fetch helpers to use the environment variable
- document the new variable in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68661e43f37c8324972b46c5687a29e7