### PR TITLE
Fix navbar modal button

### DIFF
--- a/src/renderer/components/setupTopNav.ts
+++ b/src/renderer/components/setupTopNav.ts
@@ -3,11 +3,11 @@ import { Modal } from 'bootstrap';
 
 /**
  * Sets up event listeners for the top navigation bar, particularly for the main menu modal.
- * @param {HTMLElement} topNav The top navbar container element.
+ * @param {HTMLElement} topNavButton The navbar brand element that opens the menu modal.
  */
-export function setupTopNav(topNav: HTMLElement) {
-  topNav.addEventListener('click', function () {
-    const mainMenuModal = document.getElementById('topNavBtn');
+export function setupTopNav(topNavButton: HTMLElement) {
+  topNavButton.addEventListener('click', function () {
+    const mainMenuModal = document.getElementById('navbar-main-menu-modal');
     if (mainMenuModal) {
       const bsModal = new Modal(mainMenuModal, {
         keyboard: true,

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -28,8 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeLevels();
   }
 
-  const mainMenuModal = document.getElementById('topNavBtn');
-  if (mainMenuModal) {
-    setupTopNav(mainMenuModal);
+  const mainMenuBtn = document.getElementById('navbar-main-menu-modal-btn');
+  if (mainMenuBtn) {
+    setupTopNav(mainMenuBtn);
   }
 });

--- a/test/setupTopNav.test.js
+++ b/test/setupTopNav.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import mock from 'mock-require';
+
+class ModalStub {
+  static toggled = false;
+  static lastElement = null;
+  constructor(elem) {
+    ModalStub.lastElement = elem;
+  }
+  toggle() {
+    ModalStub.toggled = true;
+  }
+}
+
+test('setupTopNav attaches listener and opens modal', () => {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><a id="navbar-main-menu-modal-btn"></a><div id="navbar-main-menu-modal"></div>`
+  );
+
+  const { document, Event } = dom.window;
+  global.document = document;
+
+  mock('bootstrap', { Modal: ModalStub });
+  const { setupTopNav } = require('../src/renderer/components/setupTopNav');
+
+  const btn = document.getElementById('navbar-main-menu-modal-btn');
+  setupTopNav(btn);
+
+  btn.dispatchEvent(new Event('click'));
+
+  assert.strictEqual(
+    ModalStub.lastElement,
+    document.getElementById('navbar-main-menu-modal')
+  );
+  assert.ok(ModalStub.toggled);
+
+  mock.stop('bootstrap');
+});


### PR DESCRIPTION
## Summary
- reference correct navbar modal button id in renderer
- open menu modal from navbar brand in `setupTopNav`
- add regression test covering the listener attachment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686621a82e7083249529ab972f9c299e