### PR TITLE
Use global fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@electron-forge/plugin-webpack": "^7.8.1",
         "@electron/fuses": "^1.8.0",
         "@types/bootstrap": "^5.2.10",
-        "@types/node-fetch": "^2.6.11",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -1608,17 +1607,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/node-forge": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@electron-forge/plugin-webpack": "^7.8.1",
     "@electron/fuses": "^1.8.0",
     "@types/bootstrap": "^5.2.10",
-    "@types/node-fetch": "^2.6.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vercel/webpack-asset-relocator-loader": "1.7.3",

--- a/src/api/fetchServerData.ts
+++ b/src/api/fetchServerData.ts
@@ -1,7 +1,6 @@
 import { stat } from 'fs/promises';
 import { promises as fs } from 'fs';
 import { getDirectories } from '../functions/fetchDirectories';
-import fetch from 'node-fetch';
 import { fetchServerEndpoints } from './fetchServerEndpoints';
 
 const SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'https://manic-launcher.vercel.app';

--- a/src/api/fetchServerEndpoints.ts
+++ b/src/api/fetchServerEndpoints.ts
@@ -1,7 +1,6 @@
 import { stat } from 'fs/promises';
 import { promises as fs } from 'fs';
 import { getDirectories } from '../functions/fetchDirectories';
-import { default as fetch } from 'node-fetch';
 
 const SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'https://manic-launcher.vercel.app';
 

--- a/src/functions/downloadFile.ts
+++ b/src/functions/downloadFile.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
-import fetch from 'node-fetch';
-import { Transform } from 'stream';
+import { Transform, Readable } from 'stream';
 import crypto from 'crypto';
 
 /**
@@ -55,8 +54,9 @@ export async function downloadFile({
     });
 
     const fileStream = fs.createWriteStream(filePath);
+    const readable = Readable.fromWeb(response.body as any);
     await new Promise<void>((resolve, reject) => {
-      response.body
+      readable
         .pipe(progressStream)
         .pipe(fileStream)
         .on('error', reject)


### PR DESCRIPTION
## Summary
- switch fetch implementations to use the global API
- remove `@types/node-fetch` dependency

## Testing
- `npm test`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_6866232d4c6c83248c11d9448ad09cd7