### PR TITLE
Fix duplicate IPC listeners

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -27,6 +27,8 @@ export type IpcChannel =
 export interface ElectronAPI {
   send: (channel: IpcChannel, data?: unknown) => void;
   receive: (channel: IpcChannel, func: (...args: unknown[]) => void) => void;
+  receiveOnce: (channel: IpcChannel, func: (...args: unknown[]) => void) => void;
+  removeAllListeners: (channel: IpcChannel) => void;
   openExternal: (url: string) => void;
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -36,5 +36,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on(channel, (_event, ...args) => func(...args));
     }
   },
+  receiveOnce: (channel: string, func: (...args: any[]) => void) => {
+    if (validReceiveChannels.includes(channel)) {
+      ipcRenderer.once(channel, (_event, ...args) => func(...args));
+    }
+  },
+  removeAllListeners: (channel: string) => {
+    if (validReceiveChannels.includes(channel)) {
+      ipcRenderer.removeAllListeners(channel);
+    }
+  },
   openExternal: shell.openExternal,
 });

--- a/src/renderer/components/domUtils.ts
+++ b/src/renderer/components/domUtils.ts
@@ -11,7 +11,8 @@ export function trimFilePath(fullPath: string): string | null {
 export function fetchDefaultDirectory(callback: (path: string) => void) {
   window.electronAPI.send(IPC_CHANNELS.GET_DIRECTORIES);
 
-  window.electronAPI.receive(IPC_CHANNELS.GET_DIRECTORIES, (response: any) => {
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.GET_DIRECTORIES);
+  window.electronAPI.receiveOnce(IPC_CHANNELS.GET_DIRECTORIES, (response: any) => {
     if (response.status && response.directories) {
       const installPathInput = document.getElementById('installPath') as HTMLInputElement;
       // Assuming 'response.directories' contains the actual directory data

--- a/src/renderer/components/initializeLevels.ts
+++ b/src/renderer/components/initializeLevels.ts
@@ -3,10 +3,11 @@ import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { debugLog } from '../../logger';
 
 export const initializeLevels = (): void => {
+  window.electronAPI?.removeAllListeners(IPC_CHANNELS.GET_LEVELS);
   window.electronAPI?.send(IPC_CHANNELS.GET_LEVELS);
 
   // Handler for receiving levels data
-  window.electronAPI?.receive(IPC_CHANNELS.GET_LEVELS, (response: any) => {
+  window.electronAPI?.receiveOnce(IPC_CHANNELS.GET_LEVELS, (response: any) => {
     if (response.status) {
       updateLevelsTable(response.levels); // Pass only the levels array
       debugLog(`Received levels: ${JSON.stringify(response.levels)}`);

--- a/src/renderer/components/initializeUrls.ts
+++ b/src/renderer/components/initializeUrls.ts
@@ -3,10 +3,11 @@ import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { debugLog } from '../../logger';
 
 export const initializeUrls = (): void => {
+  window.electronAPI?.removeAllListeners(IPC_CHANNELS.GET_URLS);
   window.electronAPI?.send(IPC_CHANNELS.GET_URLS);
 
   // Handler for receiving URL data
-  window.electronAPI?.receive(IPC_CHANNELS.GET_URLS, (response: any) => {
+  window.electronAPI?.receiveOnce(IPC_CHANNELS.GET_URLS, (response: any) => {
     if (response.status) {
       updateLinksUI(response.urls); // Pass only the URLs object
       debugLog(`Received URLs: ${JSON.stringify(response.urls)}`);

--- a/src/renderer/components/initializeVersionSelect.ts
+++ b/src/renderer/components/initializeVersionSelect.ts
@@ -2,6 +2,8 @@ import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { fetchDefaultDirectory, toggleButtonVisibility, trimFilePath } from './domUtils';
 
 export const initializeVersionSelect = (): void => {
+  window.electronAPI?.removeAllListeners(IPC_CHANNELS.VERSIONS_UPDATED);
+  window.electronAPI?.removeAllListeners(IPC_CHANNELS.ALL_VERSION_INFO);
   // Request the version information initially and upon notifications of updates
   fetchVersionData();
 

--- a/src/renderer/components/setupDirectoryDialog.ts
+++ b/src/renderer/components/setupDirectoryDialog.ts
@@ -5,6 +5,7 @@ export function setupDirectoryDialog(installPathInput: HTMLInputElement) {
   });
 
   // Handler to receive the selected directory path and update the input field
+  window.electronAPI.removeAllListeners('directory-selected');
   window.electronAPI.receive('directory-selected', (path: any) => {
     installPathInput.value = path as string;
   });

--- a/src/renderer/components/setupInstallButton.ts
+++ b/src/renderer/components/setupInstallButton.ts
@@ -5,6 +5,9 @@ import { setDisabledAppearance } from './domUtils';
 import { debugLog } from '../../logger';
 
 export function setupInstallButton(installButton: HTMLButtonElement, installPathInput: HTMLInputElement, versionSelect: HTMLSelectElement) {
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.DOWNLOAD_PROGRESS);
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.DOWNLOAD_VERSION);
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.VERSIONS_UPDATED);
   installButton.addEventListener('click', () => {
     const versionIdentifier = versionSelect.value;
     const downloadPath = installPathInput.value;

--- a/src/renderer/components/setupPlayButton.ts
+++ b/src/renderer/components/setupPlayButton.ts
@@ -4,6 +4,7 @@ import { setDisabledAppearance } from './domUtils';
 import { debugLog } from '../../logger';
 
 export function setupPlayButton(playButton: HTMLButtonElement, versionSelect: HTMLSelectElement, installPathInput: HTMLInputElement) {
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.LAUNCH_GAME);
   playButton.addEventListener('click', () => {
     const versionIdentifier = versionSelect.value;
     if (!versionIdentifier) {


### PR DESCRIPTION
## Summary
- avoid accumulating listeners by clearing or using `once`
- expose `receiveOnce` and `removeAllListeners` in `electronAPI`
- update renderer components to use new utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6866235f48e88324943a364b37499787