### PR TITLE
Refactor error handling types

### DIFF
--- a/src/api/fetchServerData.ts
+++ b/src/api/fetchServerData.ts
@@ -59,8 +59,9 @@ export async function fetchServerData({ routeName = 'launcher.all' }: { routeNam
 
     // Cache the fetched data
     await fs.writeFile(cacheFilePath, JSON.stringify({ status, data, message }), 'utf8');
-  } catch (error) {
-    message = `Error: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Error: ${err.message}`;
   }
 
   return { status, data, message };

--- a/src/api/fetchServerEndpoints.ts
+++ b/src/api/fetchServerEndpoints.ts
@@ -65,8 +65,9 @@ export async function fetchServerEndpoints({
     }
 
     return { status: true, message: 'Endpoints fetched successfully', data };
-  } catch (error: any) {
-    message = `Error fetching server endpoints: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Error fetching server endpoints: ${err.message}`;
     return { status: false, message };
   }
 }

--- a/src/fileUtils/clearDirectory.ts
+++ b/src/fileUtils/clearDirectory.ts
@@ -43,7 +43,8 @@ export async function clearDirectory({ directoryPath }: { directoryPath: string 
     }
 
     return { clean: true, message: 'Directory and all contents successfully cleared.' };
-  } catch (error: any) {
-    return { clean: false, message: `Failed to clear directory: ${error.message}` };
+  } catch (error: unknown) {
+    const err = error as Error;
+    return { clean: false, message: `Failed to clear directory: ${err.message}` };
   }
 }

--- a/src/fileUtils/createFileReadOnly.ts
+++ b/src/fileUtils/createFileReadOnly.ts
@@ -87,8 +87,9 @@ export const createFileReadOnly = async (
           hasParentDirectory,
           message,
         };
-      } catch (error: any) {
-        throw new Error(`Failed to write to the file '${filePath}' due to: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        throw new Error(`Failed to write to the file '${filePath}' due to: ${err.message}`);
       }
     })
   );

--- a/src/fileUtils/createShortcut.ts
+++ b/src/fileUtils/createShortcut.ts
@@ -44,8 +44,9 @@ export const createShortcut = async ({
       message = `URL shortcut created successfully at ${shortcutPath}`;
     }
     created = true;
-  } catch (error: any) {
-    message = `Error creating ${type} shortcut at ${shortcutPath}: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Error creating ${type} shortcut at ${shortcutPath}: ${err.message}`;
   }
 
   return { created, message };

--- a/src/fileUtils/deleteDirectoryOrFile.ts
+++ b/src/fileUtils/deleteDirectoryOrFile.ts
@@ -20,7 +20,8 @@ export async function deleteDirectoryOrFile({ directoryPath }: { directoryPath: 
       await fs.unlink(directoryPath);
       return { deleted: true, message: 'File removed successfully.' };
     }
-  } catch (error: any) {
-    return { deleted: false, message: `Failed to remove path: ${error.message}` };
+  } catch (error: unknown) {
+    const err = error as Error;
+    return { deleted: false, message: `Failed to remove path: ${err.message}` };
   }
 }

--- a/src/fileUtils/destroy.ts
+++ b/src/fileUtils/destroy.ts
@@ -51,14 +51,15 @@ export async function destroy({ pathToDestroy }: { pathToDestroy: string }): Pro
       path: pathToDestroy,
       message: destroyed ? 'Destruction completed successfully.' : 'Destruction failed. Some components could not be removed.',
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error as Error;
     return {
       destroyed: writableStatus && clearStatus && deleteStatus,
       writableStatus,
       clearStatus,
       deleteStatus,
       path: pathToDestroy,
-      message: `Error during destruction of ${pathToDestroy}: ${error.message}`,
+      message: `Error during destruction of ${pathToDestroy}: ${err.message}`,
     };
   }
 }

--- a/src/fileUtils/fileLock.ts
+++ b/src/fileUtils/fileLock.ts
@@ -16,16 +16,18 @@ const fsAccess = util.promisify(fs.access);
 export const acquireLock = async () => {
   try {
     await fsWriteFile(lockFilePath, 'locked');
-  } catch (error: any) {
-    throw new Error('Failed to acquire lock: ' + error.message);
+  } catch (error: unknown) {
+    const err = error as Error;
+    throw new Error('Failed to acquire lock: ' + err.message);
   }
 };
 
 export const releaseLock = async () => {
   try {
     await fsUnlink(lockFilePath);
-  } catch (error: any) {
-    console.error('Failed to release lock:', error.message);
+  } catch (error: unknown) {
+    const err = error as Error;
+    console.error('Failed to release lock:', err.message);
   }
 };
 

--- a/src/fileUtils/makeWritable.ts
+++ b/src/fileUtils/makeWritable.ts
@@ -36,10 +36,11 @@ export const makeWritable = async ({ dirPath }: { dirPath: string }): Promise<{ 
     } else {
       await fs.chmod(dirPath, 0o666); // Make file writable if it's not a directory
     }
-  } catch (error: any) {
-    exists = error.code !== 'ENOENT'; // Update exists based on specific error code
+  } catch (error: unknown) {
+    const err = error as Error & { code?: string };
+    exists = err.code !== 'ENOENT'; // Update exists based on specific error code
     writable = false; // Set writable to false if any error occurs
-    return { exists, writable, message: `Failed to make writable: ${dirPath}, Reason: ${error.message}` };
+    return { exists, writable, message: `Failed to make writable: ${dirPath}, Reason: ${err.message}` };
   }
 
   return { exists, writable, message: `All files and directories at ${dirPath} made writable.` };

--- a/src/fileUtils/moveFile.ts
+++ b/src/fileUtils/moveFile.ts
@@ -30,8 +30,9 @@ export const moveFile = async ({
     await rename(sourcePath, targetPath);
     message = `File moved successfully to ${targetPath}`;
     return { status: true, message, newPath: targetPath };
-  } catch (error: any) {
-    message = `Failed to move file: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to move file: ${err.message}`;
     return { status: false, message };
   }
 };

--- a/src/fileUtils/renameFile.ts
+++ b/src/fileUtils/renameFile.ts
@@ -41,8 +41,9 @@ export const renameFile = async ({
     await rename(filePath, newFilePath);
     message = `File renamed to ${finalFileName}`;
     return { status: true, message, newFilePath };
-  } catch (error: any) {
-    message = `Failed to rename file: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to rename file: ${err.message}`;
     return { status: false, message };
   }
 };

--- a/src/fileUtils/resetDirectory.ts
+++ b/src/fileUtils/resetDirectory.ts
@@ -53,13 +53,14 @@ export const resetDirectory = async ({
       existed,
       message,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error as Error;
     return {
       reset,
       destroyed,
       created,
       existed,
-      message: `Error during directory reset: ${error.message}`,
+      message: `Error during directory reset: ${err.message}`,
     };
   }
 };

--- a/src/fileUtils/verifyFile.ts
+++ b/src/fileUtils/verifyFile.ts
@@ -41,7 +41,7 @@ export const verifyFile = async (params: IVerifyFileParams): Promise<IFileDetail
     accessedAt = stats.atimeMs;
     updatedAt = stats.ctimeMs;
     createdAt = stats.birthtimeMs;
-  } catch (error: any) {
+  } catch (error: unknown) {
     // Set false as the file does not exist or error occurred
     exists = false;
   }

--- a/src/fileUtils/waitForFile.ts
+++ b/src/fileUtils/waitForFile.ts
@@ -25,11 +25,12 @@ export async function waitForFile({
     try {
       await access(filePath, fs.constants.F_OK);
       return true; // File still exists
-    } catch (error: any) {
-      if (error.code === 'ENOENT') {
+    } catch (error: unknown) {
+      const err = error as Error & { code?: string };
+      if (err.code === 'ENOENT') {
         return false; // File does not exist
       }
-      throw error; // Re-throw unexpected errors
+      throw err; // Re-throw unexpected errors
     }
   };
 
@@ -50,9 +51,10 @@ export async function waitForFile({
           if (!exists) {
             // Once `.crdownload` disappears, wait for next file creation.
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
+          const err = error as Error;
           watcher.close();
-          reject({ status: false, message: `Error monitoring file: ${error.message}` });
+          reject({ status: false, message: `Error monitoring file: ${err.message}` });
         }
       } else if (!initialFiles.has(fullPath) && eventType === 'rename') {
         // Assume the file appearing after a `.crdownload` disappears is the completed file.

--- a/src/functions/createDesktopShortcuts.ts
+++ b/src/functions/createDesktopShortcuts.ts
@@ -106,8 +106,9 @@ export const createDesktopShortcuts = async ({
       });
       filePaths.push(result.message); // Adjusting to push the returned message
     }
-  } catch (error: any) {
-    filePaths.push(`Error creating shortcuts: ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as Error;
+    filePaths.push(`Error creating shortcuts: ${err.message}`);
     status = false;
   }
 

--- a/src/functions/downloadFile.ts
+++ b/src/functions/downloadFile.ts
@@ -83,7 +83,8 @@ export async function downloadFile({
     }
 
     return { status: true, message: 'File downloaded and verified successfully.' };
-  } catch (error: any) {
-    return { status: false, message: `Error during download: ${error.message}` };
+  } catch (error: unknown) {
+    const err = error as Error;
+    return { status: false, message: `Error during download: ${err.message}` };
   }
 }

--- a/src/functions/downloadVersion.ts
+++ b/src/functions/downloadVersion.ts
@@ -58,8 +58,9 @@ export const downloadVersion = async ({
       });
       return { downloaded: downloadResult.status, message: downloadResult.message };
     }
-  } catch (error) {
-    updateStatus({ status: `Error: ${error.message}`, progress: 60 });
-    return { downloaded: false, message: `Error downloading version: ${error.message}` };
+  } catch (error: unknown) {
+    const err = error as Error;
+    updateStatus({ status: `Error: ${err.message}`, progress: 60 });
+    return { downloaded: false, message: `Error downloading version: ${err.message}` };
   }
 };

--- a/src/functions/fetchDirectories.ts
+++ b/src/functions/fetchDirectories.ts
@@ -99,10 +99,11 @@ export async function getDirectories(): Promise<{ status: boolean; message: stri
         backupSavesPath,
       },
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error as Error;
     return {
       status: false,
-      message: `Failed to fetch and ensure directories: ${error.message}`,
+      message: `Failed to fetch and ensure directories: ${err.message}`,
     };
   }
 }

--- a/src/functions/fetchInstalledVersions.ts
+++ b/src/functions/fetchInstalledVersions.ts
@@ -56,8 +56,9 @@ export const fetchInstalledVersions = async (): Promise<{
     installedVersions = Array.from(versionMap.values()).filter(v => v.directory);
     message = 'Installed versions fetched successfully.';
     return { status: true, message, installedVersions };
-  } catch (error: any) {
-    message = `Error fetching installed versions: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Error fetching installed versions: ${err.message}`;
     return { status: false, message };
   }
 };

--- a/src/functions/unpackVersion.ts
+++ b/src/functions/unpackVersion.ts
@@ -80,8 +80,9 @@ export const unpackVersion = async ({
     installPath = specificInstallPath;
     message = `Successfully unpacked ${versionToUnpack.title} into ${installPath}`;
     if (updateStatus) updateStatus({ status: 'Unpacking completed successfully.', progress: 100 });
-  } catch (error: any) {
-    message = `Error unpacking the zip file: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Error unpacking the zip file: ${err.message}`;
     if (updateStatus) updateStatus({ status: message, progress: 100 });
     unpacked = false;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,8 +29,9 @@ export const logToFile = async ({ message, filePath }: { message: string; filePa
     const finalPath = filePath || join(launcherLogsPath, 'default-log.txt');
     const timeStampedMessage = `${new Date().toISOString()}: ${message}\n`;
     await fs.appendFile(finalPath, timeStampedMessage, 'utf-8');
-  } catch (error: any) {
-    console.error(`Failed to write to log file: ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as Error;
+    console.error(`Failed to write to log file: ${err.message}`);
   }
 };
 
@@ -51,8 +52,9 @@ export const logToRuntimeLog = async ({ message }: { message: string }) => {
     }
     const launcherLogsPath = directories.launcherLogsPath;
     await logToFile({ message, filePath: join(launcherLogsPath, 'runtime-log.txt') });
-  } catch (error: any) {
-    console.error(`Failed to log runtime message: ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as Error;
+    console.error(`Failed to log runtime message: ${err.message}`);
   }
 };
 

--- a/src/main/ipcHandlers/getDirectoriesIPC.ts
+++ b/src/main/ipcHandlers/getDirectoriesIPC.ts
@@ -22,19 +22,21 @@ export const setupDirectoryHandler = async (): Promise<{ status: boolean; messag
           directories: dirResult.directories,
         });
         status = true; // Indicates successful setup of the IPC handler.
-      } catch (error: any) {
-        console.error(`Error fetching directories: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        console.error(`Error fetching directories: ${err.message}`);
         event.reply(IPC_CHANNELS.GET_DIRECTORIES, {
           status: false,
-          message: `Error fetching directories: ${error.message}`,
+          message: `Error fetching directories: ${err.message}`,
         });
       }
     });
 
     message = 'Directory handler set up successfully.';
     status = true;
-  } catch (error: any) {
-    message = `Failed to set up directory handler: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up directory handler: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupDownloadHandlers.ts
+++ b/src/main/ipcHandlers/setupDownloadHandlers.ts
@@ -62,19 +62,21 @@ export const setupDownloadHandlers = async (): Promise<{ status: boolean; messag
         } else {
           throw new Error(`Download failed: ${downloadResult.message}`);
         }
-      } catch (error: any) {
-        console.error(`Error processing version: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        console.error(`Error processing version: ${err.message}`);
         event.reply(IPC_CHANNELS.DOWNLOAD_VERSION, {
           downloaded: false,
-          message: `Error processing version: ${error.message}`,
+          message: `Error processing version: ${err.message}`,
         });
       }
     });
 
     message = 'Download handlers set up successfully.';
     status = true; // Indicates the handler was set up successfully.
-  } catch (error: any) {
-    message = `Failed to set up download handlers: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up download handlers: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupGameLaunchHandlers.ts
+++ b/src/main/ipcHandlers/setupGameLaunchHandlers.ts
@@ -17,19 +17,21 @@ export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; mess
           message: success ? 'Game launched successfully.' : 'Failed to launch game.',
         });
         status = true; // This indicates the event handler was setup successfully.
-      } catch (error: any) {
-        console.error(`Error launching game: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        console.error(`Error launching game: ${err.message}`);
         event.reply(IPC_CHANNELS.LAUNCH_GAME, {
           success: false,
-          message: `Error launching game: ${error.message}`,
+          message: `Error launching game: ${err.message}`,
         });
       }
     });
 
     message = 'Game launch handlers set up successfully.';
     status = true; // Indicates the handler was set up successfully.
-  } catch (error: any) {
-    message = `Failed to set up game launch handlers: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up game launch handlers: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupInputPathDialog.ts
+++ b/src/main/ipcHandlers/setupInputPathDialog.ts
@@ -18,17 +18,19 @@ export const setupInputPathDialog = async (): Promise<{ status: boolean; message
         } else {
           message = 'Directory selection was canceled or no directory was selected.';
         }
-      } catch (error: any) {
-        message = `Failed to open directory dialog: ${error.message}`;
+      } catch (error: unknown) {
+        const err = error as Error;
+        message = `Failed to open directory dialog: ${err.message}`;
         event.reply('directory-selection-error', message);
       }
     });
 
     status = true; // If we reach here, it means ipcMain handler was set up without error.
     message = 'Directory dialog handler setup successfully.';
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error as Error;
     status = false;
-    message = `Failed to set up directory dialog handler: ${error.message}`;
+    message = `Failed to set up directory dialog handler: ${err.message}`;
   }
 
   return { status, message };

--- a/src/main/ipcHandlers/setupLatestDownloadHandler.ts
+++ b/src/main/ipcHandlers/setupLatestDownloadHandler.ts
@@ -64,9 +64,10 @@ export const setupLatestDownloadHandler = async (): Promise<{ status: boolean; m
 
     message = 'Latest download handler set up successfully.';
     status = true; // Indicates the handler was set up successfully.
-  } catch (error: any) {
-    console.error(`Failed to set up latest download handlers: ${error.message}`);
-    message = `Failed to set up latest download handlers: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    console.error(`Failed to set up latest download handlers: ${err.message}`);
+    message = `Failed to set up latest download handlers: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupLevelHandler.ts
+++ b/src/main/ipcHandlers/setupLevelHandler.ts
@@ -20,19 +20,21 @@ export const setupLevelHandler = async (): Promise<{ status: boolean; message: s
           count: levelsResult.count,
         });
         status = true; // Indicates successful setup of the IPC handler.
-      } catch (error: any) {
-        console.error(`Error fetching levels: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        console.error(`Error fetching levels: ${err.message}`);
         event.reply(IPC_CHANNELS.GET_LEVELS, {
           status: false,
-          message: `Error fetching levels: ${error.message}`,
+          message: `Error fetching levels: ${err.message}`,
         });
       }
     });
 
     message = 'Level handler set up successfully.';
     status = true;
-  } catch (error: any) {
-    message = `Failed to set up level handler: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up level handler: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupPlaySoundHandler.ts
+++ b/src/main/ipcHandlers/setupPlaySoundHandler.ts
@@ -25,8 +25,9 @@ export const setupPlaySoundHandler = async (): Promise<{ status: boolean; messag
 
     message = 'Play sound handler set up successfully.';
     status = true;
-  } catch (error: any) {
-    message = `Failed to set up play sound handler: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up play sound handler: ${err.message}`;
     status = false;
   }
 

--- a/src/main/ipcHandlers/setupUrlHandler.ts
+++ b/src/main/ipcHandlers/setupUrlHandler.ts
@@ -19,19 +19,21 @@ export const setupUrlHandler = async (): Promise<{ status: boolean; message: str
           urls: urlResult,
         });
         status = true; // Indicates successful setup of the IPC handler.
-      } catch (error: any) {
-        console.error(`Error fetching URLs: ${error.message}`);
+      } catch (error: unknown) {
+        const err = error as Error;
+        console.error(`Error fetching URLs: ${err.message}`);
         event.reply(IPC_CHANNELS.GET_URLS, {
           status: false,
-          message: `Error fetching URLs: ${error.message}`,
+          message: `Error fetching URLs: ${err.message}`,
         });
       }
     });
 
     message = 'URL handler set up successfully.';
     status = true;
-  } catch (error: any) {
-    message = `Failed to set up URL handler: ${error.message}`;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up URL handler: ${err.message}`;
     status = false;
   }
 


### PR DESCRIPTION
## Summary
- replace all `catch (error: any)` occurrences with `unknown`
- cast error to `Error` inside catch blocks
- update major functions like `downloadVersion`, `fetchServerData` and `setupPlaySoundHandler`

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_68662341d3bc8324b9eed5fe0341f96a