### PR TITLE
Fix duplicate play-sound declaration

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -4,7 +4,6 @@ declare module '*.partial_html' {
   export default content;
 }
 
-declare module 'play-sound';
 
 export type IpcChannel =
   | 'launch-game'


### PR DESCRIPTION
## Summary
- keep `play-sound` declaration only in `src/types/play-sound.d.ts`
- remove duplicate from `global.d.ts`

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_686623d2c8088324972329c69c5870b2