### PR TITLE
Refactor to async fs APIs

### DIFF
--- a/src/functions/downloadFile.ts
+++ b/src/functions/downloadFile.ts
@@ -66,9 +66,9 @@ export async function downloadFile({
         });
     });
 
-    const stats = fs.statSync(filePath);
+    const stats = await fs.promises.stat(filePath);
     if (expectedSize !== undefined && stats.size !== expectedSize) {
-      fs.unlinkSync(filePath);
+      await fs.promises.unlink(filePath);
       return {
         status: false,
         message: `Downloaded file size does not match expected size. Expected: ${expectedSize} bytes, Got: ${stats.size} bytes`,
@@ -76,9 +76,10 @@ export async function downloadFile({
     }
 
     if (expectedMd5) {
-      const hash = crypto.createHash('md5').update(fs.readFileSync(filePath)).digest('hex');
+      const buffer = await fs.promises.readFile(filePath);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
       if (hash !== expectedMd5) {
-        fs.unlinkSync(filePath);
+        await fs.promises.unlink(filePath);
         return { status: false, message: 'MD5 checksum mismatch.' };
       }
     }

--- a/src/functions/unpackVersion.ts
+++ b/src/functions/unpackVersion.ts
@@ -28,11 +28,18 @@ export const unpackVersion = async ({
   }
 
   const specificInstallPath = path.join(installationDirectory, versionToUnpack.identifier);
-  if (fs.existsSync(specificInstallPath) && !overwriteExisting) {
+  let dirExists = false;
+  try {
+    await fs.promises.access(specificInstallPath);
+    dirExists = true;
+  } catch {
+    dirExists = false;
+  }
+  if (dirExists && !overwriteExisting) {
     throw new Error(`Installation directory at ${specificInstallPath} already exists. Use overwriteExisting to unpack again.`);
   }
 
-  if (!fs.existsSync(specificInstallPath)) {
+  if (!dirExists) {
     await createDirectory({ directory: specificInstallPath });
   }
 
@@ -57,7 +64,9 @@ export const unpackVersion = async ({
         await fs.promises.mkdir(fullPath, { recursive: true });
       } else {
         const dirPath = path.dirname(fullPath);
-        if (!fs.existsSync(dirPath)) {
+        try {
+          await fs.promises.access(dirPath);
+        } catch {
           await fs.promises.mkdir(dirPath, { recursive: true });
         }
         await zip.extract(entry.name, fullPath);
@@ -70,15 +79,21 @@ export const unpackVersion = async ({
     await zip.close();
 
     // Check for nested directory structure and flatten if necessary
-    const subdirectories = fs
-      .readdirSync(specificInstallPath)
-      .filter(subDir => fs.statSync(path.join(specificInstallPath, subDir)).isDirectory());
+    const dirEntries = await fs.promises.readdir(specificInstallPath);
+    const subdirectories: string[] = [];
+    for (const subDir of dirEntries) {
+      const stat = await fs.promises.stat(path.join(specificInstallPath, subDir));
+      if (stat.isDirectory()) {
+        subdirectories.push(subDir);
+      }
+    }
     if (subdirectories.length === 1) {
       const nestedDir = path.join(specificInstallPath, subdirectories[0]);
-      fs.readdirSync(nestedDir).forEach(file => {
-        fs.renameSync(path.join(nestedDir, file), path.join(specificInstallPath, file));
-      });
-      fs.rmdirSync(nestedDir);
+      const nestedFiles = await fs.promises.readdir(nestedDir);
+      for (const file of nestedFiles) {
+        await fs.promises.rename(path.join(nestedDir, file), path.join(specificInstallPath, file));
+      }
+      await fs.promises.rmdir(nestedDir);
     }
 
     const message = `Successfully unpacked ${versionToUnpack.title} into ${specificInstallPath}`;


### PR DESCRIPTION
## Summary
- switch to non-blocking fs APIs for downloading and unpacking
- streamline async directory checks during extraction

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve module paths)*

------
https://chatgpt.com/codex/tasks/task_b_686624e26f48832484e591453006ceeb