### PR TITLE
Document Windows-only features and guard OS code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Welcome to the official repository of **Manic Miners Launcher**, a modern launch
 ## Features:
 
 - **Easy Installation**: Set up your game with just a few clicks. No more digging through forums for install guides.
-- **Auto-Updates**: Keep your game up to date with the latest patches and content without lifting a finger.
+- **Auto-Updates (Windows only)**: Keep your game up to date with the latest patches and content without lifting a finger.
 - **Mod Support**: Easily manage and integrate mods to enhance your gameplay experience.
 - **Custom Profiles**: Set up multiple profiles for different mod configurations or save games.
 - **Performance Settings**: Tweak your game’s settings directly from the launcher for optimal performance on your machine.
 - **Online Leaderboards**: See how you rank against other players in various categories.
 - **Community Hub**: Access the latest news, guides, and forums directly through the launcher.
 - **Backup and Restore**: Safely backup your saves and profiles and restore them when needed.
+- **Shortcut Creation (Windows only)**: Optionally create Start Menu or Desktop shortcuts for quick access.
 
 ## Getting Started:
 
@@ -19,7 +20,7 @@ Welcome to the official repository of **Manic Miners Launcher**, a modern launch
 
 Before you install the Manic Miners Launcher, ensure you have the following:
 
-- **Supported OS**: Windows 7 or later. Other operating systems are currently unsupported and some features will be disabled.
+- **Supported OS**: Windows 7 or later. Other operating systems are currently unsupported and features such as auto-updates and shortcut creation will be disabled.
 - An internet connection for downloading the launcher and updates.
 - The original game files if you wish to apply mods or play certain versions.
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -28,6 +28,7 @@ export interface ElectronAPI {
   receiveOnce: (channel: IpcChannel, func: (...args: unknown[]) => void) => void;
   removeAllListeners: (channel: IpcChannel) => void;
   openExternal: (url: string) => void;
+  platform: NodeJS.Platform;
 }
 
 declare global {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -35,7 +35,12 @@ const startApp = (): void => {
   });
 };
 
-if (require('electron-squirrel-startup')) {
+
+if (process.platform !== 'win32') {
+  console.warn(
+    'This launcher is primarily designed for Windows. Some features like shortcut creation and auto-update will be disabled.'
+  );
+} else if (require('electron-squirrel-startup')) {
   app.quit();
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -47,4 +47,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
   },
   openExternal: shell.openExternal,
+  platform: process.platform,
 });

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -12,6 +12,16 @@ import { initializeLevels } from './components/initializeLevels';
 initializeVersionSelect();
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (window.electronAPI.platform !== 'win32') {
+    console.warn('Running on non-Windows platform. Shortcut options are disabled.');
+    const startMenuCb = document.getElementById('start-menu-shortcut') as HTMLInputElement | null;
+    const desktopCb = document.getElementById('desktop-shortcut') as HTMLInputElement | null;
+    [startMenuCb, desktopCb].forEach(cb => {
+      if (cb) {
+        cb.disabled = true;
+      }
+    });
+  }
   const installPaneContainer = document.getElementById('install-pane-container');
   if (installPaneContainer) {
     const playButton = document.getElementById('playButton') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- clarify which features are Windows-specific in the README
- expose the runtime platform in `preload.ts` and types
- disable shortcut checkboxes on non-Windows systems
- warn at startup when running on unsupported OSes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686627d45c108324b75c42082825b872