### PR TITLE
Fix renderer preload environment

### DIFF
--- a/src/api/fetchServerData.ts
+++ b/src/api/fetchServerData.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'fs';
 import { getDirectories } from '../functions/fetchDirectories';
 import { fetchServerEndpoints } from './fetchServerEndpoints';
 
-const SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'https://manic-launcher.vercel.app';
+const SERVER_BASE_URL =
+  typeof process !== 'undefined' && process.env?.SERVER_BASE_URL ? process.env.SERVER_BASE_URL : 'https://manic-launcher.vercel.app';
 
 interface FetchResult {
   status: boolean;

--- a/src/api/fetchServerEndpoints.ts
+++ b/src/api/fetchServerEndpoints.ts
@@ -2,7 +2,8 @@ import { stat } from 'fs/promises';
 import { promises as fs } from 'fs';
 import { getDirectories } from '../functions/fetchDirectories';
 
-const SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'https://manic-launcher.vercel.app';
+const SERVER_BASE_URL =
+  typeof process !== 'undefined' && process.env?.SERVER_BASE_URL ? process.env.SERVER_BASE_URL : 'https://manic-launcher.vercel.app';
 
 interface Endpoint {
   name: string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@ if (typeof process !== 'undefined' && (process as any).type !== 'renderer') {
 }
 
 // Flag to control verbose logging
-export const isVerbose = process.env.VERBOSE === 'true';
+export const isVerbose = typeof process !== 'undefined' && process.env ? process.env.VERBOSE === 'true' : false;
 
 /**
  * Logs a message to a file with a timestamp. Uses a specified file or a default log file if no path is provided.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,11 +39,8 @@ const startApp = (): void => {
   });
 };
 
-
 if (process.platform !== 'win32') {
-  console.warn(
-    'This launcher is primarily designed for Windows. Some features like shortcut creation and auto-update will be disabled.'
-  );
+  console.warn('This launcher is primarily designed for Windows. Some features like shortcut creation and auto-update will be disabled.');
 } else if (require('electron-squirrel-startup')) {
   app.quit();
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -46,6 +46,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeAllListeners(channel);
     }
   },
-  openExternal: shell.openExternal,
+  openExternal: (url: string) => {
+    if (typeof shell?.openExternal === 'function') {
+      shell.openExternal(url);
+    }
+  },
   platform: process.platform,
 });


### PR DESCRIPTION
## Summary
- handle undefined `process` and `shell` in preload and helper modules
- adjust warning message formatting

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68678651993c832497aade5de127761b