### PR TITLE
Fix renderer validation

### DIFF
--- a/src/renderer/components/initializeLevels.ts
+++ b/src/renderer/components/initializeLevels.ts
@@ -17,7 +17,12 @@ export const initializeLevels = (): void => {
   });
 
   // Update the UI with received levels data
-  function updateLevelsTable(levels: any[]) {
+  function updateLevelsTable(levels: any[] | undefined | null) {
+    if (!Array.isArray(levels)) {
+      console.error('Invalid levels data received:', levels);
+      return;
+    }
+
     const tableBody = document.getElementById('levelsTable').querySelector('tbody');
     if (!tableBody) {
       console.error('The levelsTable tbody element was not found.');

--- a/src/renderer/components/initializeUrls.ts
+++ b/src/renderer/components/initializeUrls.ts
@@ -17,7 +17,12 @@ export const initializeUrls = (): void => {
   });
 
   // Update the UI with received URL data
-  function updateLinksUI(urls: { [s: string]: string } | ArrayLike<unknown>) {
+  function updateLinksUI(urls: { [s: string]: string } | ArrayLike<unknown> | undefined | null) {
+    if (!urls || typeof urls !== 'object') {
+      console.error('Invalid URLs data received:', urls);
+      return;
+    }
+
     const linksContainer = document.getElementById('links-pane');
     if (!linksContainer) {
       console.error('The links-pane element was not found.');

--- a/src/renderer/components/initializeVersionSelect.ts
+++ b/src/renderer/components/initializeVersionSelect.ts
@@ -22,8 +22,12 @@ export const initializeVersionSelect = (): void => {
     updateVersionSelectUI(data);
   });
 
-  function updateVersionSelectUI(data: { versions: any; defaultVersion: any }) {
+  function updateVersionSelectUI(data: { versions?: any; defaultVersion?: any }) {
     const { versions, defaultVersion } = data;
+    if (!Array.isArray(versions)) {
+      console.error('Invalid versions data received:', versions);
+      return;
+    }
     const versionSelect = document.getElementById('versionSelect') as HTMLSelectElement;
     const installPathInput = document.getElementById('installPath') as HTMLInputElement;
 


### PR DESCRIPTION
## Summary
- add sanity checks before populating renderer UI

## Testing
- `pnpm test`
- `pnpm lint` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_b_68678c4836248324b00b6709c64c5f29