### PR TITLE
Fix macOS EPIPE issue

### DIFF
--- a/config/webpack.plugins.ts
+++ b/config/webpack.plugins.ts
@@ -3,8 +3,18 @@ import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
-export const plugins = [
-  new ForkTsCheckerWebpackPlugin({
-    logger: 'webpack-infrastructure',
-  }),
-];
+// ForkTsCheckerWebpackPlugin intermittently fails on macOS with
+// `write EPIPE` errors. To keep development working on darwin
+// systems, the plugin is disabled by default. Set FORCE_TS_CHECK=1
+// to re-enable it if needed.
+
+const shouldUsePlugin =
+  process.platform !== 'darwin' || process.env.FORCE_TS_CHECK === '1';
+
+export const plugins = shouldUsePlugin
+  ? [
+      new ForkTsCheckerWebpackPlugin({
+        logger: 'webpack-infrastructure',
+      }),
+    ]
+  : [];


### PR DESCRIPTION
## Summary
- disable ForkTsCheckerWebpackPlugin on macOS unless `FORCE_TS_CHECK=1`

## Testing
- `pnpm run lint` *(fails: Invalid option)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686798e767448324aa0d7ed642fc67d6