### PR TITLE
Update docs on macOS EPIPE workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,16 @@ If you want to build the launcher from source you'll need **Node.js 20.19.2 or n
 
 On macOS the TypeScript checker used during development can crash with `EPIPE`
 errors. The build scripts automatically disable this check on darwin systems.
-If you manually set the `FORCE_TS_CHECK=1` environment variable the plugin will
-run and may cause these crashes. Unset `FORCE_TS_CHECK` to restore the default
-behaviour.
+If you want to run the checker anyway, set the `FORCE_TS_CHECK` environment
+variable before starting the app:
+
+```bash
+export FORCE_TS_CHECK=1
+pnpm start
+```
+
+Unset `FORCE_TS_CHECK` to restore the default behaviour and avoid potential
+`EPIPE` crashes.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- document how to avoid `EPIPE` failures by leaving `FORCE_TS_CHECK` unset

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68679f84119c83248d75c28d68f72b71