### PR TITLE
Fix devtools open timing

### DIFF
--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -19,7 +19,10 @@ export const createWindow = (): void => {
   });
 
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+
   if (process.env.NODE_ENV === 'development') {
-    mainWindow.webContents.openDevTools();
+    mainWindow.webContents.once('did-finish-load', () => {
+      mainWindow.webContents.openDevTools();
+    });
   }
 };


### PR DESCRIPTION
## Summary
- ensure devtools open after the window finishes loading

## Testing
- `pnpm test`
- `pnpm start` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_b_6867a3a5d99c832499d84f131065f06c