### PR TITLE
Add basic installation checks

### DIFF
--- a/test/fetchDirectories.test.ts
+++ b/test/fetchDirectories.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+
+import { getDirectories } from '../src/functions/fetchDirectories';
+
+// Smoke test that the getDirectories function creates expected folders
+// in a custom temporary HOME directory to avoid touching real user paths.
+
+test('getDirectories creates directories in a temporary environment', async () => {
+  const tmpRoot = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  process.env.HOME = tmpRoot;
+  process.env.LOCALAPPDATA = path.join(tmpRoot, 'AppData', 'Local');
+
+  const result = await getDirectories();
+  assert.ok(result.status, result.message);
+  assert.ok(result.directories);
+
+  for (const dir of Object.values(result.directories!)) {
+    assert.ok(fs.existsSync(dir), `directory missing: ${dir}`);
+  }
+});

--- a/test/packageScripts.test.ts
+++ b/test/packageScripts.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
+
+test('package.json defines install and start scripts', () => {
+  assert.ok(pkg.scripts && typeof pkg.scripts.start === 'string');
+  assert.ok(pkg.scripts && typeof pkg.scripts.test === 'string');
+});


### PR DESCRIPTION
## Summary
- add tests for the temporary directory setup
- add tests that check required npm scripts exist

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6867a281d3448324a8b434b67d57f39c