### PR TITLE
Fix Itchio downloader browser enable error

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,10 @@
   "overrides": {
     "webpack-dev-server": "5.2.2"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "pnpm": {
+    "patchedDependencies": {
+      "itchio-downloader@0.8.1": "patches/itchio-downloader@0.8.1.patch"
+    }
+  }
 }

--- a/patches/itchio-downloader@0.8.1.patch
+++ b/patches/itchio-downloader@0.8.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/itchDownloader/initializeBrowser.js b/dist/itchDownloader/initializeBrowser.js
+index 7c520e7752aac6ca0427445d45c6353f4673b3ee..d965988ff723416c5a300e9cf0cc28900f0895e1 100644
+--- a/dist/itchDownloader/initializeBrowser.js
++++ b/dist/itchDownloader/initializeBrowser.js
+@@ -44,7 +44,6 @@ const initializeBrowser = (_a) => __awaiter(void 0, [_a], void 0, function* ({ d
+             behavior: 'allow',
+             downloadPath: path_1.default.resolve(downloadDirectory),
+         });
+-        yield client.send('Browser.enable');
+         let totalBytes = 0;
+         let fileName = '';
+         client.on('Browser.downloadWillBegin', (event) => {
+diff --git a/src/itchDownloader/initializeBrowser.ts b/src/itchDownloader/initializeBrowser.ts
+index dd86199670a33cabc62d58917b95aa3289dc01f6..5fe702db865e97017351c3de8a51aea8f5e3bf27 100644
+--- a/src/itchDownloader/initializeBrowser.ts
++++ b/src/itchDownloader/initializeBrowser.ts
+@@ -45,7 +45,6 @@ export const initializeBrowser = async ({
+       behavior: 'allow',
+       downloadPath: path.resolve(downloadDirectory),
+     });
+-    await client.send('Browser.enable' as any);
+     let totalBytes = 0;
+     let fileName = '';
+     client.on('Browser.downloadWillBegin', (event: any) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  itchio-downloader@0.8.1:
+    hash: kza4ynywzdqe4tzioauwbb7ixq
+    path: patches/itchio-downloader@0.8.1.patch
+
 importers:
 
   .:
@@ -25,7 +30,7 @@ importers:
         version: 10.1.0
       itchio-downloader:
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)
+        version: 0.8.1(patch_hash=kza4ynywzdqe4tzioauwbb7ixq)(typescript@5.8.3)
       node-stream-zip:
         specifier: ^1.15.0
         version: 1.15.0
@@ -6607,7 +6612,7 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  itchio-downloader@0.8.1(typescript@5.8.3):
+  itchio-downloader@0.8.1(patch_hash=kza4ynywzdqe4tzioauwbb7ixq)(typescript@5.8.3):
     dependencies:
       puppeteer: 24.11.2(typescript@5.8.3)
       yargs: 18.0.0


### PR DESCRIPTION
## Summary
- patch itchio-downloader package to remove `Browser.enable` usage

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6867a5497afc8324aa8f8381570d0d22