### PR TITLE
Add functional settings page

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -22,7 +22,9 @@ export type IpcChannel =
   | 'download-level'
   | 'level-download-progress'
   | 'open-directory-dialog'
-  | 'directory-selected';
+  | 'directory-selected'
+  | 'get-settings'
+  | 'set-settings';
 
 export interface ElectronAPI {
   send: (channel: IpcChannel, data?: unknown) => void;

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -15,4 +15,6 @@ export const IPC_CHANNELS = {
   GET_LEVELS: 'get-levels',
   DOWNLOAD_LEVEL: 'download-level',
   LEVEL_DOWNLOAD_PROGRESS: 'level-download-progress',
+  GET_SETTINGS: 'get-settings',
+  SET_SETTINGS: 'set-settings',
 } as const;

--- a/src/main/ipcHandlers/setupSettingsHandlers.ts
+++ b/src/main/ipcHandlers/setupSettingsHandlers.ts
@@ -1,0 +1,37 @@
+import { ipcMain } from 'electron';
+import Store from 'electron-store';
+import { IPC_CHANNELS } from './ipcChannels';
+import { LauncherSettings } from '../../types/launcherSettings';
+
+const store = new Store();
+
+const defaultSettings: LauncherSettings = {
+  playSoundOnInstall: true,
+  autoLaunchAfterInstall: false,
+  darkMode: true,
+};
+
+export const setupSettingsHandlers = async (): Promise<{ status: boolean; message: string }> => {
+  let status = false;
+  let message = '';
+
+  try {
+    ipcMain.on(IPC_CHANNELS.GET_SETTINGS, event => {
+      const settings = (store.get('settings') as LauncherSettings) || defaultSettings;
+      event.reply(IPC_CHANNELS.GET_SETTINGS, settings);
+    });
+
+    ipcMain.on(IPC_CHANNELS.SET_SETTINGS, (_event, settings: LauncherSettings) => {
+      store.set('settings', settings);
+    });
+
+    message = 'Settings handlers set up successfully.';
+    status = true;
+  } catch (error: unknown) {
+    const err = error as Error;
+    message = `Failed to set up settings handlers: ${err.message}`;
+    status = false;
+  }
+
+  return { status, message };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import { setupUrlHandler } from './ipcHandlers/setupUrlHandler';
 import { setupLevelHandler } from './ipcHandlers/setupLevelHandler';
 import { setupPlaySoundHandler } from './ipcHandlers/setupPlaySoundHandler';
 import { setupLevelDownloadHandlers } from './ipcHandlers/setupLevelDownloadHandlers';
+import { setupSettingsHandlers } from './ipcHandlers/setupSettingsHandlers';
 
 const userDataPath = path.join(app.getPath('home'), '.manic-miners-launcher');
 app.setPath('userData', userDataPath);
@@ -26,6 +27,7 @@ const startApp = (): void => {
     setupUrlHandler();
     setupLevelHandler();
     setupPlaySoundHandler();
+    setupSettingsHandlers();
   });
 
   app.on('window-all-closed', () => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -11,6 +11,8 @@ const validSendChannels = [
   IPC_CHANNELS.GET_URLS,
   IPC_CHANNELS.GET_LEVELS,
   IPC_CHANNELS.DOWNLOAD_LEVEL,
+  IPC_CHANNELS.GET_SETTINGS,
+  IPC_CHANNELS.SET_SETTINGS,
   'open-directory-dialog',
 ];
 
@@ -26,6 +28,8 @@ const validReceiveChannels = [
   IPC_CHANNELS.GET_URLS,
   IPC_CHANNELS.GET_LEVELS,
   'directory-selected',
+  IPC_CHANNELS.GET_SETTINGS,
+  IPC_CHANNELS.SET_SETTINGS,
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/components/initializeSettings.ts
+++ b/src/renderer/components/initializeSettings.ts
@@ -1,0 +1,56 @@
+import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
+import { LauncherSettings } from '../../types/launcherSettings';
+
+let currentSettings: LauncherSettings = {
+  playSoundOnInstall: true,
+  autoLaunchAfterInstall: false,
+  darkMode: true,
+};
+
+export const getCurrentSettings = (): LauncherSettings => currentSettings;
+
+export const initializeSettings = (): void => {
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.GET_SETTINGS);
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.SET_SETTINGS);
+  window.electronAPI.send(IPC_CHANNELS.GET_SETTINGS);
+
+  window.electronAPI.receiveOnce(IPC_CHANNELS.GET_SETTINGS, (settings: LauncherSettings) => {
+    currentSettings = settings;
+    applySettingsToUI();
+  });
+
+  const map = [
+    { id: 'setting-play-sound', key: 'playSoundOnInstall' },
+    { id: 'setting-auto-launch', key: 'autoLaunchAfterInstall' },
+    { id: 'setting-dark-mode', key: 'darkMode' },
+  ] as const;
+
+  map.forEach(({ id, key }) => {
+    const el = document.getElementById(id) as HTMLInputElement | null;
+    if (el) {
+      el.addEventListener('change', () => {
+        currentSettings = { ...currentSettings, [key]: el.checked } as LauncherSettings;
+        window.electronAPI.send(IPC_CHANNELS.SET_SETTINGS, currentSettings);
+        if (key === 'darkMode') {
+          toggleDarkMode(el.checked);
+        }
+      });
+    }
+  });
+};
+
+function applySettingsToUI() {
+  const play = document.getElementById('setting-play-sound') as HTMLInputElement | null;
+  const autoLaunch = document.getElementById('setting-auto-launch') as HTMLInputElement | null;
+  const darkMode = document.getElementById('setting-dark-mode') as HTMLInputElement | null;
+  if (play) play.checked = currentSettings.playSoundOnInstall;
+  if (autoLaunch) autoLaunch.checked = currentSettings.autoLaunchAfterInstall;
+  if (darkMode) {
+    darkMode.checked = currentSettings.darkMode;
+    toggleDarkMode(currentSettings.darkMode);
+  }
+}
+
+function toggleDarkMode(enabled: boolean) {
+  document.body.classList.toggle('light-mode', !enabled);
+}

--- a/src/renderer/components/setupInstallButton.ts
+++ b/src/renderer/components/setupInstallButton.ts
@@ -3,6 +3,7 @@ import { updateStatus } from './updateStatus';
 import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { setDisabledAppearance } from './domUtils';
 import { debugLog } from '../../logger';
+import { getCurrentSettings } from './initializeSettings';
 
 export function setupInstallButton(installButton: HTMLButtonElement, installPathInput: HTMLInputElement, versionSelect: HTMLSelectElement) {
   window.electronAPI.removeAllListeners(IPC_CHANNELS.DOWNLOAD_PROGRESS);
@@ -36,7 +37,13 @@ export function setupInstallButton(installButton: HTMLButtonElement, installPath
   window.electronAPI.receive(IPC_CHANNELS.DOWNLOAD_VERSION, (result: any) => {
     debugLog(result.message);
     if (result.downloaded) {
-      window.electronAPI.send(IPC_CHANNELS.PLAY_SOUND); // Request the main process to play the success sound
+      const settings = getCurrentSettings();
+      if (settings.playSoundOnInstall) {
+        window.electronAPI.send(IPC_CHANNELS.PLAY_SOUND);
+      }
+      if (settings.autoLaunchAfterInstall) {
+        window.electronAPI.send(IPC_CHANNELS.LAUNCH_GAME, versionSelect.value);
+      }
       window.electronAPI.send(IPC_CHANNELS.ALL_VERSION_INFO); // Request updated version list
     } else {
       alert('Failed to download the version: ' + result.message);

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -324,3 +324,16 @@ button.disabled {
   color: rgb(0, 0, 0) !important;
   background-color: var(--mm-green) !important;
 }
+
+body.light-mode {
+  background: #f8f9fa !important;
+  color: #000;
+}
+body.light-mode .navbar,
+body.light-mode .footer {
+  background-color: #e9ecef !important;
+}
+body.light-mode #side-pane {
+  background-color: rgba(255, 255, 255, 0.8) !important;
+  color: #000;
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -32,9 +32,6 @@
                     <a class="nav-link" href="#levels" data-bs-toggle="tab">Levels</a>
                   </li>
                   <li class="nav-item">
-                    <a class="nav-link" href="#stats" data-bs-toggle="tab">Stats</a>
-                  </li>
-                  <li class="nav-item">
                     <a class="nav-link" href="#settings" data-bs-toggle="tab">Settings</a>
                   </li>
                 </ul>
@@ -66,11 +63,21 @@
                 </div>
               </div>
             </div>
-            <div class="tab-pane fade" id="stats">
-              <div class="p-4">Statistics about the game usage...</div>
-            </div>
             <div class="tab-pane fade" id="settings">
-              <div class="p-4">Settings for the game launcher...</div>
+              <div class="p-4">
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" id="setting-play-sound" />
+                  <label class="form-check-label" for="setting-play-sound">Play sound after install</label>
+                </div>
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" id="setting-auto-launch" />
+                  <label class="form-check-label" for="setting-auto-launch">Launch game after install</label>
+                </div>
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" id="setting-dark-mode" />
+                  <label class="form-check-label" for="setting-dark-mode">Enable dark mode</label>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -8,8 +8,10 @@ import { setupDirectoryDialog } from './components/setupDirectoryDialog';
 import { initializeVersionSelect } from './components/initializeVersionSelect';
 import { initializeUrls } from './components/initializeUrls';
 import { initializeLevels } from './components/initializeLevels';
+import { initializeSettings } from './components/initializeSettings';
 
 initializeVersionSelect();
+initializeSettings();
 
 document.addEventListener('DOMContentLoaded', () => {
   if (window.electronAPI.platform !== 'win32') {

--- a/src/types/launcherSettings.ts
+++ b/src/types/launcherSettings.ts
@@ -1,0 +1,5 @@
+export interface LauncherSettings {
+  playSoundOnInstall: boolean;
+  autoLaunchAfterInstall: boolean;
+  darkMode: boolean;
+}


### PR DESCRIPTION
## Summary
- remove the unused Stats tab from the UI
- implement a real settings page with dark mode, auto launch, and sound options
- store settings with new IPC handlers
- use saved settings when installing versions

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_686cb4edac7483249f81f423dae98490