### PR TITLE
Update README environment variable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ If not provided, the launcher defaults to `https://manic-launcher.vercel.app`.
 Set this variable before running the app if you need to target a different
 server.
 
+Example:
+
+```bash
+SERVER_BASE_URL=https://my-server.example.com pnpm start
+```
+
+This variable can also be set in your operating system's environment or in a `.env` file.
+
 ## License:
 
 Manic Miners Launcher is released under the [MIT License](LICENSE). See the LICENSE file for more details.


### PR DESCRIPTION
## Summary
- document how to run with `SERVER_BASE_URL` using pnpm
- note that this variable can be set via the OS environment or in a `.env` file

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686cc361750c8324b9cad0f5d20d1cbe