### PR TITLE
Add file utility tests

### DIFF
--- a/test/clearDirectory.test.ts
+++ b/test/clearDirectory.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import { clearDirectory } from '../src/fileUtils/clearDirectory';
+
+// Test that clearDirectory recursively deletes all contents
+
+test('clearDirectory recursively removes nested contents', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const sub = path.join(dir, 'sub');
+  const deep = path.join(sub, 'deep');
+  fs.mkdirSync(deep, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'file1.txt'), '1');
+  fs.writeFileSync(path.join(sub, 'file2.txt'), '2');
+  fs.writeFileSync(path.join(deep, 'file3.txt'), '3');
+
+  const result = await clearDirectory({ directoryPath: dir });
+
+  assert.ok(result.clean, result.message);
+  const remaining = fs.readdirSync(dir);
+  assert.strictEqual(remaining.length, 0);
+  assert.ok(!fs.existsSync(sub));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test that clearDirectory creates directory if it doesn't exist
+
+test('clearDirectory creates directory when missing', async () => {
+  const dir = path.join(process.cwd(), `tmp-${Date.now()}`);
+  assert.ok(!fs.existsSync(dir));
+
+  const result = await clearDirectory({ directoryPath: dir });
+
+  assert.ok(result.clean, result.message);
+  assert.ok(fs.existsSync(dir));
+  assert.strictEqual(fs.readdirSync(dir).length, 0);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/createFileReadOnly.test.ts
+++ b/test/createFileReadOnly.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import { createFileReadOnly } from '../src/fileUtils/createFileReadOnly';
+
+// Verify that files are created with read-only permissions
+
+test('createFileReadOnly writes file with mode 444', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'read.txt');
+
+  const result = await createFileReadOnly({ filePath: file, content: 'hello' });
+
+  assert.ok(fs.existsSync(file));
+  const stats = fs.statSync(file);
+  assert.strictEqual(stats.mode & 0o777, 0o444);
+  assert.strictEqual((result as any).writable, false);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/deleteDirectoryOrFile.test.ts
+++ b/test/deleteDirectoryOrFile.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import { deleteDirectoryOrFile } from '../src/fileUtils/deleteDirectoryOrFile';
+
+// Ensure that files are removed
+
+test('deleteDirectoryOrFile removes a file', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'temp.txt');
+  fs.writeFileSync(file, 'data');
+
+  const result = await deleteDirectoryOrFile({ directoryPath: file });
+
+  assert.ok(result.deleted, result.message);
+  assert.ok(!fs.existsSync(file));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Ensure that directories with contents are removed
+
+test('deleteDirectoryOrFile removes a directory recursively', async () => {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const sub = path.join(dir, 'sub');
+  fs.mkdirSync(sub);
+  fs.writeFileSync(path.join(sub, 'file.txt'), 'content');
+
+  const result = await deleteDirectoryOrFile({ directoryPath: sub });
+
+  assert.ok(result.deleted, result.message);
+  assert.ok(!fs.existsSync(sub));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- test recursive directory removal using `clearDirectory`
- test read-only mode creation using `createFileReadOnly`
- test file and directory deletion with `deleteDirectoryOrFile`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686cc3693e7c8324b69c5eee9574fca8