### PR TITLE
Fix path trimming for Windows & POSIX

### DIFF
--- a/src/renderer/components/domUtils.ts
+++ b/src/renderer/components/domUtils.ts
@@ -2,10 +2,13 @@ import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
 import { debugLog } from '../../logger';
 
 export function trimFilePath(fullPath: string): string | null {
-  if (!fullPath || fullPath.lastIndexOf('\\') === -1) {
+  if (!fullPath) {
     return null;
   }
-  const lastSlashIndex = fullPath.lastIndexOf('\\');
+  const lastSlashIndex = Math.max(fullPath.lastIndexOf('/'), fullPath.lastIndexOf('\\'));
+  if (lastSlashIndex === -1) {
+    return null;
+  }
   return fullPath.substring(0, lastSlashIndex);
 }
 export function fetchDefaultDirectory(callback: (path: string) => void) {

--- a/test/trimFilePath.test.ts
+++ b/test/trimFilePath.test.ts
@@ -1,0 +1,14 @@
+/// <reference path="../global.d.ts" />
+import test from 'node:test';
+import assert from 'node:assert';
+import { trimFilePath } from '../src/renderer/components/domUtils';
+
+test('trimFilePath handles Windows paths', () => {
+  const result = trimFilePath('C:\\foo\\bar\\file.txt');
+  assert.strictEqual(result, 'C:\\foo\\bar');
+});
+
+test('trimFilePath handles POSIX paths', () => {
+  const result = trimFilePath('/usr/local/bin/file.txt');
+  assert.strictEqual(result, '/usr/local/bin');
+});


### PR DESCRIPTION
## Summary
- handle both `/` and `\` when trimming install path
- test path trimming for POSIX and Windows styles

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686cc35394188324bfdc3d7e1fda32bd