### PR TITLE
Add directory dialog ipc channels

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -6,27 +6,9 @@ declare module '*.partial_html' {
 
 declare module 'mock-require';
 
-export type IpcChannel =
-  | 'launch-game'
-  | 'versions-updated'
-  | 'request-version-information'
-  | 'set-selected-version'
-  | 'get-selected-version'
-  | 'check-version-installed'
-  | 'select-install-directory'
-  | 'download-version'
-  | 'download-status'
-  | 'download-progress'
-  | 'get-directories'
-  | 'play-sound'
-  | 'get-urls'
-  | 'get-levels'
-  | 'download-level'
-  | 'level-download-progress'
-  | 'open-directory-dialog'
-  | 'directory-selected'
-  | 'get-settings'
-  | 'set-settings';
+import { IPC_CHANNELS } from './src/main/ipcHandlers/ipcChannels';
+
+export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
 
 export interface ElectronAPI {
   send: (channel: IpcChannel, data?: unknown) => void;

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -15,6 +15,8 @@ export const IPC_CHANNELS = {
   GET_LEVELS: 'get-levels',
   DOWNLOAD_LEVEL: 'download-level',
   LEVEL_DOWNLOAD_PROGRESS: 'level-download-progress',
+  OPEN_DIRECTORY_DIALOG: 'open-directory-dialog',
+  DIRECTORY_SELECTED: 'directory-selected',
   GET_SETTINGS: 'get-settings',
   SET_SETTINGS: 'set-settings',
 } as const;

--- a/src/main/ipcHandlers/setupInputPathDialog.ts
+++ b/src/main/ipcHandlers/setupInputPathDialog.ts
@@ -1,18 +1,19 @@
 import { ipcMain, dialog } from 'electron';
+import { IPC_CHANNELS } from './ipcChannels';
 
 export const setupInputPathDialog = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
   let status = false;
 
   try {
-    ipcMain.on('open-directory-dialog', async event => {
+    ipcMain.on(IPC_CHANNELS.OPEN_DIRECTORY_DIALOG, async event => {
       try {
         const result = await dialog.showOpenDialog({
           properties: ['openDirectory'],
         });
 
         if (!result.canceled && result.filePaths.length > 0) {
-          event.reply('directory-selected', result.filePaths[0]);
+          event.reply(IPC_CHANNELS.DIRECTORY_SELECTED, result.filePaths[0]);
           message = 'Directory selected successfully.';
           status = true;
         } else {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -13,7 +13,7 @@ const validSendChannels = [
   IPC_CHANNELS.DOWNLOAD_LEVEL,
   IPC_CHANNELS.GET_SETTINGS,
   IPC_CHANNELS.SET_SETTINGS,
-  'open-directory-dialog',
+  IPC_CHANNELS.OPEN_DIRECTORY_DIALOG,
 ];
 
 const validReceiveChannels = [
@@ -27,7 +27,7 @@ const validReceiveChannels = [
   IPC_CHANNELS.ALL_VERSION_INFO,
   IPC_CHANNELS.GET_URLS,
   IPC_CHANNELS.GET_LEVELS,
-  'directory-selected',
+  IPC_CHANNELS.DIRECTORY_SELECTED,
   IPC_CHANNELS.GET_SETTINGS,
   IPC_CHANNELS.SET_SETTINGS,
 ];

--- a/src/renderer/components/setupDirectoryDialog.ts
+++ b/src/renderer/components/setupDirectoryDialog.ts
@@ -1,12 +1,14 @@
+import { IPC_CHANNELS } from '../../main/ipcHandlers/ipcChannels';
+
 export function setupDirectoryDialog(installPathInput: HTMLInputElement) {
   installPathInput.addEventListener('click', () => {
     // Trigger the directory dialog on click
-    window.electronAPI.send('open-directory-dialog');
+    window.electronAPI.send(IPC_CHANNELS.OPEN_DIRECTORY_DIALOG);
   });
 
   // Handler to receive the selected directory path and update the input field
-  window.electronAPI.removeAllListeners('directory-selected');
-  window.electronAPI.receive('directory-selected', (path: any) => {
+  window.electronAPI.removeAllListeners(IPC_CHANNELS.DIRECTORY_SELECTED);
+  window.electronAPI.receive(IPC_CHANNELS.DIRECTORY_SELECTED, (path: any) => {
     installPathInput.value = path as string;
   });
 }


### PR DESCRIPTION
## Summary
- reference new `IPC_CHANNELS` constants for opening a directory dialog
- expose all IPC channels automatically in the global type definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686cd4099e8883248fe0f4e1ec658b49