### PR TITLE
Fix nav menu backdrop lingering

### DIFF
--- a/src/renderer/components/setupTopNav.ts
+++ b/src/renderer/components/setupTopNav.ts
@@ -6,13 +6,13 @@ import { Modal } from 'bootstrap';
  * @param {HTMLElement} topNavButton The navbar brand element that opens the menu modal.
  */
 export function setupTopNav(topNavButton: HTMLElement) {
-  topNavButton.addEventListener('click', function () {
-    const mainMenuModal = document.getElementById('navbar-main-menu-modal');
-    if (mainMenuModal) {
-      const bsModal = new Modal(mainMenuModal, {
-        keyboard: true,
-      });
-      bsModal.toggle();
-    }
+  const mainMenuModal = document.getElementById('navbar-main-menu-modal');
+  if (!mainMenuModal) return;
+
+  const bsModal = Modal.getOrCreateInstance(mainMenuModal, { keyboard: true });
+
+  topNavButton.addEventListener('click', function (e) {
+    e.preventDefault();
+    bsModal.show();
   });
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -14,23 +14,11 @@
             <!-- Navigation Bar -->
             <nav class="navbar navbar-expand-lg navbar-dark py-3">
               <div class="container-fluid">
-                <a
-                  id="navbar-main-menu-modal-btn"
-                  class="navbar-brand d-flex align-items-center not-draggable"
-                  href="#"
-                  data-bs-toggle="modal"
-                  data-bs-target="#navbar-main-menu-modal"
-                >
+                <a id="navbar-main-menu-modal-btn" class="navbar-brand d-flex align-items-center not-draggable" href="#">
                   <div id="brand-image" class="d-inline-block align-text-top"></div>
                   Manic Miners HQ
                 </a>
-                <a
-                  id="navbar-menu-btn"
-                  class="icon-button not-draggable ms-auto"
-                  href="#"
-                  data-bs-toggle="modal"
-                  data-bs-target="#navbar-main-menu-modal"
-                >
+                <a id="navbar-menu-btn" class="icon-button not-draggable ms-auto" href="#">
                   <i class="fas fa-bars"></i>
                 </a>
               </div>

--- a/src/ui/partials/topNavbarElement.ts
+++ b/src/ui/partials/topNavbarElement.ts
@@ -1,12 +1,11 @@
 export const topNavbarElement = `
 <nav class="navbar navbar-expand-lg navbar-dark py-3 fixed-top">
     <div class="container-fluid">
-        <a id="navbar-main-menu-modal-btn" class="navbar-brand d-flex align-items-center not-draggable" href="#" data-bs-toggle="modal"
-            data-bs-target="#navbar-main-menu-modal">
+        <a id="navbar-main-menu-modal-btn" class="navbar-brand d-flex align-items-center not-draggable" href="#">
             <div id="brand-image" class="d-inline-block align-text-top"></div>
             Manic Miners HQ
         </a>
-        <a id="navbar-menu-btn" class="icon-button not-draggable ms-auto" href="#" data-bs-toggle="modal" data-bs-target="#navbar-main-menu-modal">
+        <a id="navbar-menu-btn" class="icon-button not-draggable ms-auto" href="#">
             <i class="fas fa-bars"></i>
         </a>
     </div>

--- a/test/setupTopNav.test.js
+++ b/test/setupTopNav.test.js
@@ -4,13 +4,24 @@ import { JSDOM } from 'jsdom';
 import mock from 'mock-require';
 
 class ModalStub {
-  static toggled = false;
+  static shown = false;
   static lastElement = null;
+  static instance = null;
+
   constructor(elem) {
     ModalStub.lastElement = elem;
   }
-  toggle() {
-    ModalStub.toggled = true;
+
+  show() {
+    ModalStub.shown = true;
+  }
+
+  static getOrCreateInstance(elem) {
+    if (!ModalStub.instance) {
+      ModalStub.instance = new ModalStub(elem);
+    }
+    ModalStub.lastElement = elem;
+    return ModalStub.instance;
   }
 }
 
@@ -29,7 +40,7 @@ test('setupTopNav attaches listener and opens modal', () => {
   btn.dispatchEvent(new Event('click'));
 
   assert.strictEqual(ModalStub.lastElement, document.getElementById('navbar-main-menu-modal'));
-  assert.ok(ModalStub.toggled);
+  assert.ok(ModalStub.shown);
 
   mock.stop('bootstrap');
 });


### PR DESCRIPTION
## Summary
- keep a single Bootstrap modal instance for the nav menu
- remove data attributes from nav buttons
- update top nav partial and unit test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_686cd88781a88324a6de270519bcb1c1