### PR TITLE
Add navigation handling

### DIFF
--- a/src/renderer/components/setupNavigation.ts
+++ b/src/renderer/components/setupNavigation.ts
@@ -1,0 +1,35 @@
+import { Modal } from 'bootstrap';
+
+export function setupNavigation() {
+  const modalEl = document.getElementById('navbar-main-menu-modal');
+  if (!modalEl) return;
+  const bsModal = Modal.getOrCreateInstance(modalEl);
+
+  const links: { id: string; target: string }[] = [
+    { id: 'nav-home', target: 'news' },
+    { id: 'nav-levels', target: 'levels' },
+    { id: 'nav-library', target: 'library' },
+    { id: 'nav-store', target: 'store' },
+    { id: 'nav-settings', target: 'settings' },
+  ];
+
+  links.forEach(({ id, target }) => {
+    const link = document.getElementById(id);
+    if (!link) return;
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      showTab(target);
+      bsModal.hide();
+    });
+  });
+
+  function showTab(target: string) {
+    document.querySelectorAll('.tab-content .tab-pane').forEach(p => {
+      p.classList.remove('show', 'active');
+    });
+    const pane = document.getElementById(target);
+    if (pane) {
+      pane.classList.add('show', 'active');
+    }
+  }
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -49,6 +49,12 @@
                 </div>
               </div>
             </div>
+            <div class="tab-pane fade" id="library">
+              <div class="p-4">Your installed content will appear here.</div>
+            </div>
+            <div class="tab-pane fade" id="store">
+              <div class="p-4">Store content coming soon.</div>
+            </div>
             <div class="tab-pane fade" id="settings">
               <div class="p-4">
                 <div class="form-check mb-2">
@@ -140,23 +146,23 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <a href="#" class="d-flex align-items-center justify-content-start mb-2">
+            <a id="nav-home" href="#" class="d-flex align-items-center justify-content-start mb-2">
               <div id="lmsMenuImg" class="menu-icon mr-2"></div>
               Home
             </a>
-            <a href="#" class="d-flex align-items-center justify-content-start mb-2">
+            <a id="nav-levels" href="#" class="d-flex align-items-center justify-content-start mb-2">
               <div id="levelsMenuImg" class="menu-icon mr-2"></div>
               Levels
             </a>
-            <a href="#" class="d-flex align-items-center justify-content-start mb-2">
+            <a id="nav-library" href="#" class="d-flex align-items-center justify-content-start mb-2">
               <div id="teleportMenuImg" class="menu-icon mr-2"></div>
               Library
             </a>
-            <a href="#" class="d-flex align-items-center justify-content-start mb-2">
+            <a id="nav-store" href="#" class="d-flex align-items-center justify-content-start mb-2">
               <div id="tsMenuImg" class="menu-icon mr-2"></div>
               Store
             </a>
-            <a href="#" class="d-flex align-items-center justify-content-start mb-2">
+            <a id="nav-settings" href="#" class="d-flex align-items-center justify-content-start mb-2">
               <div id="supportMenuImg" class="menu-icon mr-2"></div>
               Settings
             </a>

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -9,6 +9,7 @@ import { initializeVersionSelect } from './components/initializeVersionSelect';
 import { initializeUrls } from './components/initializeUrls';
 import { initializeLevels } from './components/initializeLevels';
 import { initializeSettings } from './components/initializeSettings';
+import { setupNavigation } from './components/setupNavigation';
 
 initializeVersionSelect();
 initializeSettings();
@@ -44,4 +45,6 @@ document.addEventListener('DOMContentLoaded', () => {
   menuBtns.forEach(btn => {
     if (btn) setupTopNav(btn as HTMLElement);
   });
+
+  setupNavigation();
 });


### PR DESCRIPTION
## Summary
- hook up navigation modal links to switch tabs
- create placeholder tabs for Library and Store
- initialize navigation events on page load

## Testing
- `pnpm test` *(fails: cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_b_686cda6553988324a316c43eef48494c