### PR TITLE
Fix devtools and GPU errors on startup

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,11 @@ import { setupPlaySoundHandler } from './ipcHandlers/setupPlaySoundHandler';
 import { setupLevelDownloadHandlers } from './ipcHandlers/setupLevelDownloadHandlers';
 import { setupSettingsHandlers } from './ipcHandlers/setupSettingsHandlers';
 
+// Disable hardware acceleration to avoid GPU-related errors in some environments
+app.disableHardwareAcceleration();
+// Prevent Chrome DevTools from attempting to use unsupported Autofill features
+app.commandLine.appendSwitch('disable-features', 'Autofill');
+
 const userDataPath = path.join(app.getPath('home'), '.manic-miners-launcher');
 app.setPath('userData', userDataPath);
 


### PR DESCRIPTION
## Summary
- disable hardware acceleration to prevent invalid GPU mailbox errors
- disable the Autofill feature in devtools to stop console errors

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686ce15458a48324beb8f47f3a52a9e2