### PR TITLE
Fix progress bar positioning

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -74,7 +74,7 @@
           </div>
 
           <div id="bottom-navbar-container">
-            <nav class="navbar navbar-expand-lg navbar-dark py-3 footer">
+            <nav class="navbar navbar-expand-lg navbar-dark py-3 fixed-bottom footer">
               <div class="container-fluid">
                 <div class="progress custom-progress not-draggable">
                   <div


### PR DESCRIPTION
## Summary
- ensure the download progress bar stays pinned to the bottom

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686ce1fb02288324af83103f63b131e4