### PR TITLE
Fix startup errors

### DIFF
--- a/src/main/ipcHandlers/setupSettingsHandlers.ts
+++ b/src/main/ipcHandlers/setupSettingsHandlers.ts
@@ -3,7 +3,7 @@ import Store from 'electron-store';
 import { IPC_CHANNELS } from './ipcChannels';
 import { LauncherSettings } from '../../types/launcherSettings';
 
-const store = new Store();
+const store = new Store() as any;
 
 const defaultSettings: LauncherSettings = {
   playSoundOnInstall: true,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,9 @@
 import { shell, contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../main/ipcHandlers/ipcChannels';
 
-const validSendChannels = [
+type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
+
+const validSendChannels: IpcChannel[] = [
   IPC_CHANNELS.GET_DIRECTORIES,
   IPC_CHANNELS.LAUNCH_GAME,
   IPC_CHANNELS.DOWNLOAD_VERSION,
@@ -16,7 +18,7 @@ const validSendChannels = [
   IPC_CHANNELS.OPEN_DIRECTORY_DIALOG,
 ];
 
-const validReceiveChannels = [
+const validReceiveChannels: IpcChannel[] = [
   IPC_CHANNELS.GET_DIRECTORIES,
   IPC_CHANNELS.LAUNCH_GAME,
   IPC_CHANNELS.DOWNLOAD_PROGRESS,
@@ -33,22 +35,22 @@ const validReceiveChannels = [
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  send: (channel: string, data?: any) => {
+  send: (channel: IpcChannel, data?: any) => {
     if (validSendChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
     }
   },
-  receive: (channel: string, func: (...args: any[]) => void) => {
+  receive: (channel: IpcChannel, func: (...args: any[]) => void) => {
     if (validReceiveChannels.includes(channel)) {
       ipcRenderer.on(channel, (_event, ...args) => func(...args));
     }
   },
-  receiveOnce: (channel: string, func: (...args: any[]) => void) => {
+  receiveOnce: (channel: IpcChannel, func: (...args: any[]) => void) => {
     if (validReceiveChannels.includes(channel)) {
       ipcRenderer.once(channel, (_event, ...args) => func(...args));
     }
   },
-  removeAllListeners: (channel: string) => {
+  removeAllListeners: (channel: IpcChannel) => {
     if (validReceiveChannels.includes(channel)) {
       ipcRenderer.removeAllListeners(channel);
     }


### PR DESCRIPTION
## Summary
- coerce electron-store instance to any to avoid typing issues
- tighten preload IPC channel types

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json`
- `pnpm start`

------
https://chatgpt.com/codex/tasks/task_b_686ce8dcf9a483248fa13e1df83304ef