### PR TITLE
Fix electron install with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,13 @@
   "pnpm": {
     "patchedDependencies": {
       "itchio-downloader@0.8.1": "patches/itchio-downloader@0.8.1.patch"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "puppeteer"
+    ],
+    "onlyBuiltDependencies": [
+      "electron",
+      "electron-winstaller"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- allow electron's install script to run by default

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm run start` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_b_686d5ef779ec83249a3db485bda26cc1