### PR TITLE
Fix progress bar overlay

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -113,6 +113,9 @@ textarea {
   text-align: center;
   color: white; /* Ensures the text is readable on darker backgrounds */
   font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .btn-success,
@@ -136,6 +139,12 @@ textarea {
   padding: 0;
   height: 70px;
   justify-content: space-evenly;
+}
+
+.sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  z-index: 1020;
 }
 #footer a {
   background: transparent;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -58,7 +58,7 @@
           </div>
 
           <div id="bottom-navbar-container">
-            <nav class="navbar navbar-expand-lg navbar-dark py-3 fixed-bottom footer">
+            <nav class="navbar navbar-expand-lg navbar-dark py-3 sticky-bottom footer">
               <div class="container-fluid">
                 <div class="progress custom-progress not-draggable">
                   <div

--- a/src/ui/partials/progressBarElement.ts
+++ b/src/ui/partials/progressBarElement.ts
@@ -1,5 +1,5 @@
 export const progressBarElement = `
-<nav class="navbar navbar-expand-lg navbar-dark py-3 fixed-bottom footer draggableArea">
+<nav class="navbar navbar-expand-lg navbar-dark py-3 sticky-bottom footer draggableArea">
   <div class="container-fluid footer-container draggableArea">
     <div class="progress custom-progress not-draggable draggableArea">
       <div


### PR DESCRIPTION
## Summary
- restrict progress bar to main content instead of spanning entire viewport
- ensure long status text doesn't spill out of progress bar

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prettier issues)*

------
https://chatgpt.com/codex/tasks/task_b_686da29814b483249373f9c8b240ed98