### PR TITLE
Add ipc handler wrapper

### DIFF
--- a/src/main/ipcHandlers/getDirectoriesIPC.ts
+++ b/src/main/ipcHandlers/getDirectoriesIPC.ts
@@ -2,35 +2,28 @@ import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { getDirectories } from '../../functions/fetchDirectories';
 import { debugLog } from '../../logger';
+import { withIpcHandler } from './withIpcHandler';
 
 export const setupDirectoryHandler = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
   let status = false;
 
   try {
-    ipcMain.on(IPC_CHANNELS.GET_DIRECTORIES, async event => {
-      try {
+    ipcMain.on(
+      IPC_CHANNELS.GET_DIRECTORIES,
+      withIpcHandler(IPC_CHANNELS.GET_DIRECTORIES, async event => {
         const dirResult = await getDirectories();
         if (!dirResult.status) {
           throw new Error(dirResult.message);
         }
         debugLog(`Sending directory data: ${JSON.stringify(dirResult.directories)}`);
-
-        event.reply(IPC_CHANNELS.GET_DIRECTORIES, {
+        return {
           status: true,
           message: 'Directories fetched successfully',
           directories: dirResult.directories,
-        });
-        status = true; // Indicates successful setup of the IPC handler.
-      } catch (error: unknown) {
-        const err = error as Error;
-        console.error(`Error fetching directories: ${err.message}`);
-        event.reply(IPC_CHANNELS.GET_DIRECTORIES, {
-          status: false,
-          message: `Error fetching directories: ${err.message}`,
-        });
-      }
-    });
+        };
+      })
+    );
 
     message = 'Directory handler set up successfully.';
     status = true;

--- a/src/main/ipcHandlers/setupDownloadHandlers.ts
+++ b/src/main/ipcHandlers/setupDownloadHandlers.ts
@@ -6,6 +6,7 @@ import { DownloadGameResponse, downloadGame } from 'itchio-downloader';
 import { debugLog } from '../../logger';
 import { fetchInstalledVersions } from '../../functions/fetchInstalledVersions';
 import Store from 'electron-store';
+import { withIpcHandler } from './withIpcHandler';
 
 const store = new Store() as any;
 
@@ -14,73 +15,66 @@ export const setupDownloadHandlers = async (): Promise<{ status: boolean; messag
   let status = false;
 
   try {
-    ipcMain.on(IPC_CHANNELS.DOWNLOAD_VERSION, async (event, { version, downloadPath }) => {
-      debugLog(`Downloading version: ${version} to ${downloadPath}`);
-      //latest version only do this for a download instead -->
-      const { filePath, metaData, metadataPath, message, status } = (await downloadGame({
-        itchGameUrl: 'https://baraklava.itch.io/manic-miners',
-        downloadDirectory: downloadPath,
-        onProgress: ({ bytesReceived, totalBytes, fileName }) => {
-          const progress = totalBytes ? Math.floor((bytesReceived / totalBytes) * 100) : 0;
-          event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, {
-            progress,
-            status: `Downloading ${fileName ?? 'game'}...`,
-          });
-        },
-      })) as DownloadGameResponse;
-      //<-- latest version only do this for a download instead
+    ipcMain.on(
+      IPC_CHANNELS.DOWNLOAD_VERSION,
+      withIpcHandler(IPC_CHANNELS.DOWNLOAD_VERSION, async (event, { version, downloadPath }) => {
+        debugLog(`Downloading version: ${version} to ${downloadPath}`);
+        const { filePath, metaData, metadataPath, message, status } = (await downloadGame({
+          itchGameUrl: 'https://baraklava.itch.io/manic-miners',
+          downloadDirectory: downloadPath,
+          onProgress: ({ bytesReceived, totalBytes, fileName }) => {
+            const progress = totalBytes ? Math.floor((bytesReceived / totalBytes) * 100) : 0;
+            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, {
+              progress,
+              status: `Downloading ${fileName ?? 'game'}...`,
+            });
+          },
+        })) as DownloadGameResponse;
 
-      debugLog(`${filePath} ${metaData} ${metadataPath} ${message} ${status}`);
-      try {
+        debugLog(`${filePath} ${metaData} ${metadataPath} ${message} ${status}`);
+
         const downloadResult = await downloadVersion({
           versionIdentifier: version,
           downloadPath,
-          updateStatus: (status: any) => {
-            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, status);
+          updateStatus: (statusObj: any) => {
+            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, statusObj);
           },
         });
 
-        if (downloadResult.downloaded) {
-          const unpackResult = await unpackVersion({
-            versionIdentifier: version,
-            installationDirectory: downloadPath,
-            updateStatus: (status: any) => {
-              event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, status);
-            },
-          });
-
-          if (unpackResult.unpacked) {
-            const installedVersions = await fetchInstalledVersions();
-            const newSelectedVersion = installedVersions.installedVersions.find((v: { identifier: any }) => v.identifier === version);
-
-            if (newSelectedVersion) {
-              store.set('current-selected-version', newSelectedVersion);
-              event.sender.send(IPC_CHANNELS.VERSIONS_UPDATED);
-            }
-
-            event.reply(IPC_CHANNELS.DOWNLOAD_VERSION, {
-              downloaded: true,
-              unpacked: true,
-              message: unpackResult.message,
-            });
-          } else {
-            throw new Error(`Unpacking failed: ${unpackResult.message}`);
-          }
-        } else {
+        if (!downloadResult.downloaded) {
           throw new Error(`Download failed: ${downloadResult.message}`);
         }
-      } catch (error: unknown) {
-        const err = error as Error;
-        console.error(`Error processing version: ${err.message}`);
-        event.reply(IPC_CHANNELS.DOWNLOAD_VERSION, {
-          downloaded: false,
-          message: `Error processing version: ${err.message}`,
+
+        const unpackResult = await unpackVersion({
+          versionIdentifier: version,
+          installationDirectory: downloadPath,
+          updateStatus: (statusObj: any) => {
+            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, statusObj);
+          },
         });
-      }
-    });
+
+        if (!unpackResult.unpacked) {
+          throw new Error(`Unpacking failed: ${unpackResult.message}`);
+        }
+
+        const installedVersions = await fetchInstalledVersions();
+        const newSelectedVersion = installedVersions.installedVersions.find((v: { identifier: any }) => v.identifier === version);
+
+        if (newSelectedVersion) {
+          store.set('current-selected-version', newSelectedVersion);
+          event.sender.send(IPC_CHANNELS.VERSIONS_UPDATED);
+        }
+
+        return {
+          downloaded: true,
+          unpacked: true,
+          message: unpackResult.message,
+        };
+      })
+    );
 
     message = 'Download handlers set up successfully.';
-    status = true; // Indicates the handler was set up successfully.
+    status = true;
   } catch (error: unknown) {
     const err = error as Error;
     message = `Failed to set up download handlers: ${err.message}`;

--- a/src/main/ipcHandlers/setupGameLaunchHandlers.ts
+++ b/src/main/ipcHandlers/setupGameLaunchHandlers.ts
@@ -2,33 +2,27 @@ import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from './ipcChannels';
 import { handleGameLaunch } from '../../functions/handleGameLaunch';
 import { debugLog } from '../../logger';
+import { withIpcHandler } from './withIpcHandler';
 
 export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; message: string }> => {
   let message = '';
   let status = false;
 
   try {
-    ipcMain.on(IPC_CHANNELS.LAUNCH_GAME, async (event, versionIdentifier) => {
-      debugLog(`Launching game with version: ${versionIdentifier}`);
-      try {
+    ipcMain.on(
+      IPC_CHANNELS.LAUNCH_GAME,
+      withIpcHandler(IPC_CHANNELS.LAUNCH_GAME, async (event, versionIdentifier) => {
+        debugLog(`Launching game with version: ${versionIdentifier}`);
         const success = await handleGameLaunch({ versionIdentifier });
-        event.reply(IPC_CHANNELS.LAUNCH_GAME, {
+        return {
           success,
           message: success ? 'Game launched successfully.' : 'Failed to launch game.',
-        });
-        status = true; // This indicates the event handler was setup successfully.
-      } catch (error: unknown) {
-        const err = error as Error;
-        console.error(`Error launching game: ${err.message}`);
-        event.reply(IPC_CHANNELS.LAUNCH_GAME, {
-          success: false,
-          message: `Error launching game: ${err.message}`,
-        });
-      }
-    });
+        };
+      })
+    );
 
     message = 'Game launch handlers set up successfully.';
-    status = true; // Indicates the handler was set up successfully.
+    status = true;
   } catch (error: unknown) {
     const err = error as Error;
     message = `Failed to set up game launch handlers: ${err.message}`;

--- a/src/main/ipcHandlers/withIpcHandler.ts
+++ b/src/main/ipcHandlers/withIpcHandler.ts
@@ -1,0 +1,24 @@
+import { IpcMainEvent } from 'electron';
+
+/**
+ * Wraps an asynchronous IPC handler with standardized try/catch logic and
+ * automatic `event.reply` calls.
+ *
+ * @param replyChannel The channel to send replies on.
+ * @param fn The actual handler function to execute.
+ */
+export const withIpcHandler = <Args extends any[], Result>(
+  replyChannel: string,
+  fn: (event: IpcMainEvent, ...args: Args) => Promise<Result>
+) => {
+  return async (event: IpcMainEvent, ...args: Args): Promise<void> => {
+    try {
+      const result = await fn(event, ...args);
+      event.reply(replyChannel, result as any);
+    } catch (error: unknown) {
+      const err = error as Error;
+      console.error(`IPC handler error on ${replyChannel}: ${err.message}`);
+      event.reply(replyChannel, { status: false, message: err.message });
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- add `withIpcHandler` utility for standardized IPC error handling
- refactor `setupDownloadHandlers`, `setupGameLaunchHandlers` and directory handlers to use the wrapper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686da81bb6b08324b32d877d2735250b