### PR TITLE
Add temp dir helper & refactor tests

### DIFF
--- a/test/clearDirectory.test.ts
+++ b/test/clearDirectory.test.ts
@@ -2,12 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert';
 import fs from 'fs';
 import path from 'path';
+import { createTempDir, cleanupTempDir } from './helpers/temp';
 import { clearDirectory } from '../src/fileUtils/clearDirectory';
 
 // Test that clearDirectory recursively deletes all contents
 
 test('clearDirectory recursively removes nested contents', async () => {
-  const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+  const dir = createTempDir();
   const sub = path.join(dir, 'sub');
   const deep = path.join(sub, 'deep');
   fs.mkdirSync(deep, { recursive: true });
@@ -22,7 +23,7 @@ test('clearDirectory recursively removes nested contents', async () => {
   assert.strictEqual(remaining.length, 0);
   assert.ok(!fs.existsSync(sub));
 
-  fs.rmSync(dir, { recursive: true, force: true });
+  cleanupTempDir(dir);
 });
 
 // Test that clearDirectory creates directory if it doesn't exist

--- a/test/helpers/temp.ts
+++ b/test/helpers/temp.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+export function createTempDir(prefix = 'tmp-'): string {
+  return fs.mkdtempSync(path.join(process.cwd(), prefix));
+}
+
+export function cleanupTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add reusable temp dir utilities
- apply utilities in download and directory tests

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_686dcda782ac832499beb226a317d05e