### PR TITLE
Fix renderer CSP and require error

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self'"
+    />
     <title>Manic Miners HQ</title>
   </head>
 


### PR DESCRIPTION
## Summary of Changes
- add CSP meta tag to renderer HTML
- lazy-load `getDirectories` in logger to avoid renderer `require` usage

## Testing Steps
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_686df024b37c8324ac84d7590398a799