### PR TITLE
Remove Bootstrap dependency

### DIFF
--- a/src/renderer/components/modalHelpers.ts
+++ b/src/renderer/components/modalHelpers.ts
@@ -1,0 +1,21 @@
+export function createModal(modalEl: HTMLElement) {
+  const closeButtons = modalEl.querySelectorAll('[data-bs-dismiss="modal"]');
+  closeButtons.forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      hide();
+    });
+  });
+
+  function show() {
+    modalEl.classList.add('show');
+    modalEl.style.display = 'block';
+  }
+
+  function hide() {
+    modalEl.classList.remove('show');
+    modalEl.style.display = 'none';
+  }
+
+  return { show, hide };
+}

--- a/src/renderer/components/setupNavigation.ts
+++ b/src/renderer/components/setupNavigation.ts
@@ -1,9 +1,9 @@
-import { Modal } from 'bootstrap';
+import { createModal } from './modalHelpers';
 
 export function setupNavigation() {
   const modalEl = document.getElementById('navbar-main-menu-modal');
   if (!modalEl) return;
-  const bsModal = Modal.getOrCreateInstance(modalEl);
+  const modal = createModal(modalEl);
 
   const links: { id: string; target: string }[] = [
     { id: 'nav-home', target: 'news' },
@@ -18,7 +18,7 @@ export function setupNavigation() {
     link.addEventListener('click', e => {
       e.preventDefault();
       showTab(target);
-      bsModal.hide();
+      modal.hide();
     });
   });
 

--- a/src/renderer/components/setupTopNav.ts
+++ b/src/renderer/components/setupTopNav.ts
@@ -1,5 +1,5 @@
 // setupTopNav.ts
-import { Modal } from 'bootstrap';
+import { createModal } from './modalHelpers';
 
 /**
  * Sets up event listeners for the top navigation bar, particularly for the main menu modal.
@@ -9,10 +9,10 @@ export function setupTopNav(topNavButton: HTMLElement) {
   const mainMenuModal = document.getElementById('navbar-main-menu-modal');
   if (!mainMenuModal) return;
 
-  const bsModal = Modal.getOrCreateInstance(mainMenuModal, { keyboard: true });
+  const modal = createModal(mainMenuModal);
 
   topNavButton.addEventListener('click', function (e) {
     e.preventDefault();
-    bsModal.show();
+    modal.show();
   });
 }


### PR DESCRIPTION
## Summary
- drop Bootstrap imports from navigation components
- create a tiny helper to show/hide the modal without Bootstrap

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `pnpm start` *(fails to run Electron due to missing display server)*

------
https://chatgpt.com/codex/tasks/task_b_686df9cf25988324b1a9de413290a5bb