### PR TITLE
Fix CSP for webpack-dev-server

### DIFF
--- a/config/webpack.renderer.config.ts
+++ b/config/webpack.renderer.config.ts
@@ -4,6 +4,7 @@ import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
 
 export const rendererConfig: Configuration = {
+  devtool: process.env.NODE_ENV === 'development' ? 'source-map' : false,
   module: {
     rules,
   },

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -39,7 +39,7 @@ const config: ForgeConfig = {
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "font-src 'self' https://fonts.gstatic.com; " +
         "img-src 'self' data:; " +
-        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       contentSecurityPolicy:
         "default-src 'self'; " +
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +


### PR DESCRIPTION
## Summary
- allow `unsafe-eval` in the dev CSP to prevent EvalError when running webpack dev server
- disable webpack's eval-based devtool by using `source-map`

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686dfb3f8508832482947d53241f88fa