### PR TITLE
Fix CSP warning

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -39,7 +39,7 @@ const config: ForgeConfig = {
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "font-src 'self' https://fonts.gstatic.com; " +
         "img-src 'self' data:; " +
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+        "script-src 'self' 'unsafe-inline'",
       contentSecurityPolicy:
         "default-src 'self'; " +
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +


### PR DESCRIPTION
## Summary
- remove `unsafe-eval` from the devContentSecurityPolicy in `forge.config.ts`

## Testing
- `pnpm lint` *(fails: Cannot lint due to prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_686dff364dfc8324880a7db8d7328caf