### PR TITLE
Fix devtools autofill errors

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,10 @@ import { setupSettingsHandlers } from './ipcHandlers/setupSettingsHandlers';
 // Disable hardware acceleration to avoid GPU-related errors in some environments
 app.disableHardwareAcceleration();
 // Prevent Chrome DevTools from attempting to use unsupported Autofill features
-app.commandLine.appendSwitch('disable-features', 'Autofill');
+// Disable additional Autofill-related features to avoid protocol errors in DevTools
+// Some Chrome DevTools versions attempt to enable these features even though
+// Electron does not implement the corresponding protocol domain.
+app.commandLine.appendSwitch('disable-features', 'Autofill,AutofillAssistant,AutofillServerCommunication');
 
 const userDataPath = path.join(app.getPath('home'), '.manic-miners-launcher');
 app.setPath('userData', userDataPath);


### PR DESCRIPTION
## Summary
- extend disabling of Chrome autofill features so DevTools won't attempt unsupported commands

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686e0115832c8324a4f5b6a997b58072