### PR TITLE
Fix export in fetchLevels

### DIFF
--- a/src/api/fetchLevels.ts
+++ b/src/api/fetchLevels.ts
@@ -15,5 +15,5 @@ export async function fetchLevels(): Promise<LevelsResponse> {
     levels: data.levels as Level[],
   };
 }
-\nexport { Level, LevelsResponse } from '../types';
 
+export type { Level, LevelsResponse } from '../types';


### PR DESCRIPTION
## Summary
- fix erroneous newline in `fetchLevels` that prevented type re-exports

## Testing
- `npm run lint` *(fails: prettier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_686e05ff235c8324b246971de93fa76d