### PR TITLE
Fix webpack dev server CSP

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -39,7 +39,7 @@ const config: ForgeConfig = {
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "font-src 'self' https://fonts.gstatic.com; " +
         "img-src 'self' data:; " +
-        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       contentSecurityPolicy:
         "default-src 'self'; " +
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +


### PR DESCRIPTION
## Summary
- loosen the CSP for development

## Testing
- `pnpm install`
- `pnpm lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686ebe85fea88324bf31e9716f73c2d9