### PR TITLE
Fix router start page and sticky header

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -17,7 +17,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <HashRouter>
         <div className="flex flex-col h-screen bg-background overflow-hidden">
 
           <LauncherHeader />

--- a/launcher-gui/src/components/LauncherHeader.tsx
+++ b/launcher-gui/src/components/LauncherHeader.tsx
@@ -4,7 +4,7 @@ import { Navigation } from "./Navigation";
 
 export function LauncherHeader() {
   return (
-    <header className="border-b border-border mining-surface">
+    <header className="sticky top-0 z-50 border-b border-border mining-surface">
       <div className="container mx-auto p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">
@@ -26,5 +26,4 @@ export function LauncherHeader() {
         <Navigation />
       </div>
     </header>
-  );
-}
+  );}


### PR DESCRIPTION
## Summary
- use `HashRouter` correctly so packaged app opens to `/` instead of a 404
- keep the navigation header fixed using Tailwind's `sticky` class

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ESLint froze or produced no output)*

------
https://chatgpt.com/codex/tasks/task_b_686ef63431148324bbb4fb56cc6782b2