### PR TITLE
Fix home routing

### DIFF
--- a/launcher-gui/src/main.tsx
+++ b/launcher-gui/src/main.tsx
@@ -2,4 +2,10 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+// Always land on the same route as the Home button ("/").
+// This avoids hitting the NotFound page on first launch.
+if (window.location.hash !== '#/') {
+  window.location.hash = '#/';
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,6 +15,12 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <script>
+      // Match the route used by the Home button ("/") on initial load
+      if (location.hash !== '#/') {
+        location.hash = '#/';
+      }
+    </script>
     <script type="module" crossorigin src="./assets/index-D2J1rXLo.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-Cvc8lc9o.css">
   </head>


### PR DESCRIPTION
## Summary
- ensure the renderer sets the hash to `/` before React loads
- force the same hash when the app starts

## Testing
- `pnpm install`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686f274f9678832488576efdadb5dbe5