### PR TITLE
Fix root routing

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { LauncherHeader } from "@/components/LauncherHeader";
 import { InstalledLevelsProvider } from "./hooks/useInstalledLevels";
 import Index from "./pages/Index";
@@ -19,7 +19,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <HashRouter>
+        <BrowserRouter>
           <div className="flex flex-col h-screen bg-background overflow-hidden">
             <LauncherHeader />
             <main className="flex-1 overflow-y-auto pt-32">
@@ -33,7 +33,7 @@ const App = () => (
               </Routes>
             </main>
           </div>
-        </HashRouter>
+        </BrowserRouter>
       </TooltipProvider>
     </InstalledLevelsProvider>
   </QueryClientProvider>

--- a/launcher-gui/src/main.tsx
+++ b/launcher-gui/src/main.tsx
@@ -2,11 +2,5 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-// Always land on the same route as the Home button ("/").
-// This avoids hitting the NotFound page on first launch.
-if (window.location.hash !== '#/') {
-
-  window.location.hash = '#/';
-}
-
 createRoot(document.getElementById('root')!).render(<App />);
+

--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -19,16 +19,14 @@ export const createWindow = (): void => {
     frame: false, // This will remove the frame
   });
 
-  // Ensure the renderer starts on the Home page in both dev and prod.
-  // When packaged, loadFile lets us explicitly set the hash portion so
-  // React Router's HashRouter receives '/'. During development
-  // MAIN_WINDOW_WEBPACK_ENTRY points to the dev server URL, so we
-  // continue using loadURL with the '#/' hash appended.
+  // Load the root path without a hash in both dev and production.
+  // In development MAIN_WINDOW_WEBPACK_ENTRY is a URL; in production
+  // we load the packaged HTML file directly.
   if (MAIN_WINDOW_WEBPACK_ENTRY.startsWith('http')) {
-    mainWindow.loadURL(`${MAIN_WINDOW_WEBPACK_ENTRY}#/`);
+    mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
   } else {
     const indexPath = path.join(__dirname, '../renderer/index.html');
-    mainWindow.loadFile(indexPath, { hash: '/' });
+    mainWindow.loadFile(indexPath);
   }
 
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,12 +15,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-    <script>
-      // Match the route used by the Home button ("/") on initial load
-      if (location.hash !== '#/') {
-        location.hash = '#/';
-      }
-    </script>
+    
     <script type="module" crossorigin src="./assets/index-D2J1rXLo.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-Cvc8lc9o.css">
   </head>


### PR DESCRIPTION
## Summary
- load renderer at `/` instead of using a `#/` hash
- update the renderer bundle to remove location hash logic
- drop the hash router in the GUI and use `BrowserRouter`

## Testing
- `pnpm lint` (fails: eslint errors in `launcher-gui`)


------
https://chatgpt.com/codex/tasks/task_b_686f3478a4b483248c0f770112773d08