### PR TITLE
Fix routing back to hash-based mode

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import { LauncherHeader } from "@/components/LauncherHeader";
 import { InstalledLevelsProvider } from "./hooks/useInstalledLevels";
 import Index from "./pages/Index";
@@ -19,7 +19,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <HashRouter>
           <div className="flex flex-col h-screen bg-background overflow-hidden">
             <LauncherHeader />
             <main className="flex-1 overflow-y-auto pt-32">
@@ -33,7 +33,7 @@ const App = () => (
               </Routes>
             </main>
           </div>
-        </BrowserRouter>
+        </HashRouter>
       </TooltipProvider>
     </InstalledLevelsProvider>
   </QueryClientProvider>

--- a/launcher-gui/src/main.tsx
+++ b/launcher-gui/src/main.tsx
@@ -2,5 +2,11 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+// Always land on the same route as the Home button ("/").
+// This avoids hitting the NotFound page on first launch.
+if (window.location.hash !== '#/') {
+  window.location.hash = '#/';
+}
+
 createRoot(document.getElementById('root')!).render(<App />);
 

--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -19,14 +19,16 @@ export const createWindow = (): void => {
     frame: false, // This will remove the frame
   });
 
-  // Load the root path without a hash in both dev and production.
-  // In development MAIN_WINDOW_WEBPACK_ENTRY is a URL; in production
-  // we load the packaged HTML file directly.
+  // Ensure the renderer starts on the Home page in both dev and prod.
+  // When packaged, loadFile lets us explicitly set the hash portion so
+  // React Router's HashRouter receives '/'. During development
+  // MAIN_WINDOW_WEBPACK_ENTRY points to the dev server URL, so we
+  // continue using loadURL with the '#/' hash appended.
   if (MAIN_WINDOW_WEBPACK_ENTRY.startsWith('http')) {
-    mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+    mainWindow.loadURL(`${MAIN_WINDOW_WEBPACK_ENTRY}#/`);
   } else {
     const indexPath = path.join(__dirname, '../renderer/index.html');
-    mainWindow.loadFile(indexPath);
+    mainWindow.loadFile(indexPath, { hash: '/' });
   }
 
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -16,6 +16,12 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     
+    <script>
+      // Match the route used by the Home button ("/") on initial load
+      if (location.hash !== '#/') {
+        location.hash = '#/';
+      }
+    </script>
     <script type="module" crossorigin src="./assets/index-D2J1rXLo.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-Cvc8lc9o.css">
   </head>


### PR DESCRIPTION
## Summary
- revert to HashRouter to avoid 404 errors
- ensure default page loads with `#/` hash
- update Electron window loader accordingly

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f3b66220083248395943bce621949