### PR TITLE
Fix asset loading paths

### DIFF
--- a/config/webpack.renderer.config.ts
+++ b/config/webpack.renderer.config.ts
@@ -1,4 +1,5 @@
 import type { Configuration } from 'webpack';
+import path from 'path';
 
 import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
@@ -20,6 +21,9 @@ export const rendererConfig: Configuration = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.mp3'],
+    alias: {
+      '/assets': path.resolve(__dirname, '../src/renderer/assets'),
+    },
     fallback: {
       fs: false,
       path: false,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -16,8 +16,8 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     
-    <script type="module" crossorigin src="./assets/index-D2J1rXLo.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-Cvc8lc9o.css">
+    <script type="module" crossorigin src="/assets/index-D2J1rXLo.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Cvc8lc9o.css">
   </head>
 
   <body>

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,5 +1,5 @@
 // renderer.ts - minimal loader for React-based GUI
-import './assets/index-Cvc8lc9o.css';
-import './assets/index-D2J1rXLo.js';
+import '/assets/index-Cvc8lc9o.css';
+import '/assets/index-D2J1rXLo.js';
 
 console.log('New GUI assets loaded');


### PR DESCRIPTION
## Summary
- use absolute `/assets/` paths in HTML
- point renderer imports at `/assets/`
- alias webpack config to resolve `/assets`
- rebuild GUI to verify Electron launches

## Testing
- `pnpm --dir launcher-gui build:dev`
- `pnpm start`

------
https://chatgpt.com/codex/tasks/task_b_686f548951ac83248d658ac4075f33ce