### PR TITLE
Add development CSP

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -25,7 +25,7 @@ const config: ForgeConfig = {
         config: rendererConfig,
         entryPoints: [
           {
-            html: './src/renderer/index.html', 
+            html: './src/renderer/index.html',
             js: './src/renderer/renderer.ts',
             name: 'main_window',
             preload: {
@@ -34,6 +34,8 @@ const config: ForgeConfig = {
           },
         ],
       },
+      devContentSecurityPolicy:
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';",
     }),
     new FusesPlugin({
       version: FuseVersion.V1,


### PR DESCRIPTION
## Summary
- set development CSP for WebpackPlugin so `unsafe-eval` is omitted

## Testing
- `pnpm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_b_686f548a6f7c8324a55e6a7c003d92b5