### PR TITLE
Fix default logger port conflict

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -34,8 +34,10 @@ const config: ForgeConfig = {
           },
         ],
       },
-      devContentSecurityPolicy:
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';",
+      // Avoid collisions with other applications by using a
+      // non-default port for the web-multi-logger.
+      loggerPort: 9010,
+      devContentSecurityPolicy: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';",
     }),
     new FusesPlugin({
       version: FuseVersion.V1,


### PR DESCRIPTION
## Summary
- set a custom `loggerPort` in `forge.config.ts` to avoid collisions with port 9000 during development

## Testing
- `pnpm format`
- `pnpm start > /tmp/start.log 2>&1 && tail -n 10 /tmp/start.log`


------
https://chatgpt.com/codex/tasks/task_b_686f54801ca48324a6fe6dd470143da2