### PR TITLE
Adjust launcher page padding

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -17,7 +17,12 @@ const App = () => (
       <HashRouter>
         <div className="flex flex-col h-screen bg-background overflow-hidden">
           <LauncherHeader />
-          <main className="flex-1 overflow-y-auto pt-32">
+          {/*
+           * Provide enough top padding so content isn't hidden beneath the
+           * fixed header/navigation bar. This value was increased to
+           * accommodate the header height.
+           */}
+          <main className="flex-1 overflow-y-auto pt-36">
             <Routes>
               <Route path="/" element={<Index />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}


### PR DESCRIPTION
## Summary
- ensure content sits below the fixed header by increasing padding

No unused `app/data/messages.json` directory was found, so no deletion was needed.

## Testing
- `pnpm format`
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f70fc17088324ab8b075bfd759910