### PR TITLE
Add wine support for non-Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Manic Miners Launcher
+
+This project is an Electron-based launcher for the game **Manic Miners**. The launcher downloads and manages multiple game versions and provides a simple user interface for starting the game.
+
+## Requirements
+
+- Node.js 20 or later
+- pnpm package manager
+- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable and falls back to `wine`.
+
+Make sure Wine is installed and available in your `PATH` when running the launcher on non-Windows systems.
+
+## Development
+
+Install dependencies and start the launcher in development mode:
+
+```bash
+pnpm install
+pnpm start
+```
+
+## Packaging
+
+Use Electron Forge to package distributables:
+
+```bash
+pnpm make
+```

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from 'child_process';
+import { logToFile } from '../logger';
+
+/**
+ * Checks if the compatibility launcher (Wine or custom) is available.
+ * @returns true if the command can be executed, otherwise false.
+ */
+export const checkCompatLauncher = (): boolean => {
+  if (process.platform === 'win32') return true;
+
+  const compatCmd = process.env.COMPAT_LAUNCHER || 'wine';
+  const result = spawnSync(compatCmd, ['--version'], { stdio: 'ignore' });
+  if (result.error || result.status !== 0) {
+    logToFile({
+      message: `Compatibility launcher '${compatCmd}' not available: ${result.error?.message || 'exit code ' + result.status}`,
+    });
+    return false;
+  }
+
+  return true;
+};

--- a/src/functions/handleGameLaunch.ts
+++ b/src/functions/handleGameLaunch.ts
@@ -1,20 +1,32 @@
 import { logToFile } from '../logger';
 import { launchExecutable } from './launchExecutable';
 import { fetchInstalledVersions } from './fetchInstalledVersions';
+import { checkCompatLauncher } from './checkCompatLauncher';
 
 /**
  * Function to handle the launching of a specific game version or the first available version if no identifier is provided.
  * @param versionIdentifier Optional identifier for a specific version to launch.
- * @returns Promise<boolean> indicating whether the game was successfully launched.
+ * @returns Result object with status and message.
  */
-export const handleGameLaunch = async ({ versionIdentifier }: { versionIdentifier?: string }): Promise<boolean> => {
+export const handleGameLaunch = async ({
+  versionIdentifier,
+}: {
+  versionIdentifier?: string;
+}): Promise<{ status: boolean; message: string }> => {
   try {
     logToFile({ message: `Received request to launch game version: '${versionIdentifier || 'No specific version requested'}'` });
+
+    if (!checkCompatLauncher()) {
+      const message = 'Wine is required to launch the game on non-Windows systems.';
+      return { status: false, message };
+    }
+
     const installedVersions = await fetchInstalledVersions();
 
     if (!installedVersions.status || !installedVersions.installedVersions || installedVersions.installedVersions.length === 0) {
-      logToFile({ message: 'No installations found or failed to fetch installations.' });
-      return false;
+      const message = 'No installations found or failed to fetch installations.';
+      logToFile({ message });
+      return { status: false, message };
     }
 
     // Determine which version to launch
@@ -27,22 +39,27 @@ export const handleGameLaunch = async ({ versionIdentifier }: { versionIdentifie
 
     // Check if the version has an executable to launch
     if (!versionToLaunch.executablePath) {
-      logToFile({ message: `No executable files found for the selected version: ${versionToLaunch.identifier}` });
-      return false;
+      const message = `No executable files found for the selected version: ${versionToLaunch.identifier}`;
+      logToFile({ message });
+      return { status: false, message };
     }
 
     const launchResults = await launchExecutable({ executablePath: versionToLaunch.executablePath });
     logToFile({ message: launchResults.message });
 
     if (launchResults.status) {
-      logToFile({ message: `The executable for version '${versionToLaunch.identifier}' ran successfully.` });
-      return true;
+      const message = `The executable for version '${versionToLaunch.identifier}' ran successfully.`;
+      logToFile({ message });
+      return { status: true, message };
     } else {
-      logToFile({ message: `The executable for version '${versionToLaunch.identifier}' failed with exit code: ${launchResults.exitCode}` });
-      return false;
+      const message = `The executable for version '${versionToLaunch.identifier}' failed with exit code: ${launchResults.exitCode}`;
+      logToFile({ message });
+      return { status: false, message };
     }
   } catch (error) {
-    logToFile({ message: `Failed to launch game: ${error.message}` });
-    return false;
+    const err = error as Error;
+    const message = `Failed to launch game: ${err.message}`;
+    logToFile({ message });
+    return { status: false, message };
   }
 };

--- a/src/main/ipcHandlers/setupGameLaunchHandlers.ts
+++ b/src/main/ipcHandlers/setupGameLaunchHandlers.ts
@@ -13,10 +13,10 @@ export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; mess
       IPC_CHANNELS.LAUNCH_GAME,
       withIpcHandler(IPC_CHANNELS.LAUNCH_GAME, async (event, versionIdentifier) => {
         debugLog(`Launching game with version: ${versionIdentifier}`);
-        const success = await handleGameLaunch({ versionIdentifier });
+        const { status: success, message: launchMessage } = await handleGameLaunch({ versionIdentifier });
         return {
           success,
-          message: success ? 'Game launched successfully.' : 'Failed to launch game.',
+          message: launchMessage,
         };
       })
     );


### PR DESCRIPTION
## Summary
- check for wine before launching on non-Windows systems
- expose launch status message to the renderer
- add a README documenting the wine requirement

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f7169d5588324bf6db756111ce2ee