### PR TITLE
Fix news panel height limit

### DIFF
--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -85,7 +85,7 @@ export function NewsPanel() {
         <CardDescription className="text-muted-foreground">Latest updates and announcements</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="space-y-4 max-h-64 overflow-y-auto">
+        <div className="space-y-4">
           {messages.length === 0 ? (
             <p className="text-muted-foreground text-center py-4">No messages available</p>
           ) : (


### PR DESCRIPTION
## Summary
- remove max height limit from launcher news panel

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_686f73ee2a288324bf2049661d29cca1