### PR TITLE
Fix CSP to allow API requests

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -34,7 +34,8 @@ const config: ForgeConfig = {
           },
         ],
       },
-      devContentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
+      devContentSecurityPolicy:
+        "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app;",
     }),
     new FusesPlugin({
       version: FuseVersion.V1,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,6 +15,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app;"
+    />
     
     <script type="module" crossorigin src="/assets/index.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index.css">


### PR DESCRIPTION
## Summary
- update content security policy in forge config
- add CSP meta tag for the renderer to allow manic-launcher API

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f76f806208324b6dea3920c5ac6da