### PR TITLE
Auto download Wine for Linux game launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 
 - Node.js 20 or later
 - pnpm package manager
-- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable and falls back to `wine`.
+- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, the launcher will automatically download a portable Wine build and use it.
 
-Make sure Wine is installed and available in your `PATH` when running the launcher on non-Windows systems.
+No manual Wine installation is necessary on supported platforms.
 
 ## Development
 

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -1,17 +1,74 @@
 import { spawnSync } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
+import StreamZip from 'node-stream-zip';
+import { getDirectories } from './fetchDirectories';
+import { downloadFile } from './downloadFile';
+import { extractZipEntries, flattenSingleSubdirectory } from './unpackHelpers';
+
+const DEFAULT_WINE_URL = process.env.WINE_DOWNLOAD_URL || 'https://manic-launcher.vercel.app/wine/wine-portable.zip';
 
 /**
- * Checks if the compatibility launcher (Wine or custom) is available.
- * @returns true if the command can be executed, otherwise false.
+ * Ensures a compatibility launcher (Wine or custom) is available.
+ * If not found, attempts to download a portable Wine distribution.
  */
-export const checkCompatLauncher = (): boolean => {
-  if (process.platform === 'win32') return true;
-
-  const compatCmd = process.env.COMPAT_LAUNCHER || 'wine';
-  const result = spawnSync(compatCmd, ['--version'], { stdio: 'ignore' });
-  if (result.error || result.status !== 0) {
-    return false;
+export const checkCompatLauncher = async (): Promise<{
+  status: boolean;
+  message: string;
+  compatPath?: string;
+}> => {
+  if (process.platform === 'win32') {
+    return { status: true, message: 'Windows does not require Wine.' };
   }
 
-  return true;
+  const testCommand = (cmd: string): boolean => {
+    const result = spawnSync(cmd, ['--version'], { stdio: 'ignore' });
+    return !result.error && result.status === 0;
+  };
+
+  const envCmd = process.env.COMPAT_LAUNCHER;
+  if (envCmd && testCommand(envCmd)) {
+    return { status: true, message: '', compatPath: envCmd };
+  }
+
+  if (testCommand('wine')) {
+    return { status: true, message: '', compatPath: 'wine' };
+  }
+
+  try {
+    const { directories } = await getDirectories();
+    const wineDir = path.join(directories.launcherInstallPath, 'wine');
+    const wineExe = path.join(wineDir, 'wine');
+    try {
+      await fs.access(wineExe);
+      if (testCommand(wineExe)) {
+        return { status: true, message: '', compatPath: wineExe };
+      }
+    } catch {}
+
+    const wineZip = path.join(directories.launcherInstallPath, 'wine.zip');
+    const downloadResult = await downloadFile({
+      downloadUrl: DEFAULT_WINE_URL,
+      filePath: wineZip,
+    });
+    if (!downloadResult.status) {
+      return { status: false, message: downloadResult.message };
+    }
+
+    const zip = new StreamZip.async({ file: wineZip });
+    await extractZipEntries({ zip, targetPath: wineDir });
+    await zip.close();
+    await flattenSingleSubdirectory(wineDir);
+    await fs.unlink(wineZip);
+    await fs.chmod(wineExe, 0o755);
+
+    if (testCommand(wineExe)) {
+      return { status: true, message: 'Wine downloaded.', compatPath: wineExe };
+    }
+
+    return { status: false, message: 'Wine download failed to run.' };
+  } catch (err) {
+    const error = err as Error;
+    return { status: false, message: `Wine setup failed: ${error.message}` };
+  }
 };

--- a/src/functions/launchExecutable.ts
+++ b/src/functions/launchExecutable.ts
@@ -8,14 +8,16 @@ import { spawn } from 'child_process';
 
 export const launchExecutable = ({
   executablePath,
+  compatLauncher,
 }: {
   executablePath: string;
+  compatLauncher?: string;
 }): Promise<{ status: boolean; message: string; exitCode?: number; veryShortRun?: boolean }> => {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
 
     const useCompat = process.platform !== 'win32';
-    const compatCmd = process.env.COMPAT_LAUNCHER || 'wine';
+    const compatCmd = compatLauncher || process.env.COMPAT_LAUNCHER || 'wine';
     const spawnCmd = useCompat ? compatCmd : executablePath;
     const spawnArgs = useCompat ? [executablePath] : [];
 

--- a/src/main/ipcHandlers/setupGameLaunchHandlers.ts
+++ b/src/main/ipcHandlers/setupGameLaunchHandlers.ts
@@ -11,7 +11,9 @@ export const setupGameLaunchHandlers = async (): Promise<{ status: boolean; mess
     ipcMain.on(
       IPC_CHANNELS.LAUNCH_GAME,
       withIpcHandler(IPC_CHANNELS.LAUNCH_GAME, async (event, versionIdentifier) => {
-        const success = await handleGameLaunch({ versionIdentifier });
+        const { status: success, message: launchMessage } = await handleGameLaunch({
+          versionIdentifier,
+        });
         return {
           success,
           message: launchMessage,


### PR DESCRIPTION
## Summary
- automatically ensure a Wine executable exists on Linux
- use the downloaded Wine when launching the game
- fix IPC handler to forward launch messages
- document that Wine will be downloaded automatically

## Testing
- `pnpm run format`
- `pnpm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f769678ac8324956340316f3a5451