### PR TITLE
Enable Wine fallback on Linux/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 
 - Node.js 20 or later
 - pnpm package manager
-- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, the launcher will automatically download a portable Wine build and use it.
+- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher first tries the command from the `COMPAT_LAUNCHER` environment variable and then searches for `wine` or `wine64`. If no compatible command is found, it will automatically download a portable Wine build using the URL defined by `WINE_DOWNLOAD_URL` (defaults to our hosted build) and use it.
 
 No manual Wine installation is necessary on supported platforms.
 

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -26,13 +26,21 @@ export const checkCompatLauncher = async (): Promise<{
     return !result.error && result.status === 0;
   };
 
+  const pickFirstWorking = (commands: string[]): string | undefined => {
+    for (const c of commands) {
+      if (testCommand(c)) return c;
+    }
+    return undefined;
+  };
+
   const envCmd = process.env.COMPAT_LAUNCHER;
   if (envCmd && testCommand(envCmd)) {
     return { status: true, message: '', compatPath: envCmd };
   }
 
-  if (testCommand('wine')) {
-    return { status: true, message: '', compatPath: 'wine' };
+  const systemWine = pickFirstWorking(['wine', 'wine64']);
+  if (systemWine) {
+    return { status: true, message: '', compatPath: systemWine };
   }
 
   try {


### PR DESCRIPTION
## Summary
- improve README with details about Wine usage
- detect `wine64` if available on Linux/macOS
- factor common command detection in `checkCompatLauncher`

## Testing
- `pnpm install --ignore-scripts`
- `pnpm format`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_686f82d45b208324aa77975afbf866f4