### PR TITLE
Add Wine bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 
 - Node.js 20 or later
 - pnpm package manager
-- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, the launcher will automatically download a portable Wine build and use it.
+- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, it searches for common Wine executables such as `wine` or `wine64` and falls back to automatically downloading a portable Wine build if none are available.
 
-No manual Wine installation is necessary on supported platforms.
+If a compatible command cannot be found the launcher automatically downloads a portable Wine build. No manual Wine installation is necessary on supported platforms. You can also run `pnpm run download:wine` to prefetch the Wine bundle before packaging or launching.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"launcher-gui/src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
     "update-git-url": "node scripts/updatePackageJson.js",
-    "generate:assets": "ts-node scripts/generateAssets.ts"
+    "generate:assets": "ts-node scripts/generateAssets.ts",
+    "download:wine": "ts-node scripts/downloadWine.ts"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.1",

--- a/scripts/downloadWine.ts
+++ b/scripts/downloadWine.ts
@@ -1,0 +1,11 @@
+import { checkCompatLauncher } from '../src/functions/checkCompatLauncher';
+
+(async () => {
+  const result = await checkCompatLauncher();
+  if (result.status) {
+    console.log(`Compatibility layer available at: ${result.compatPath || 'system default'}`);
+  } else {
+    console.error(`Failed to set up Wine: ${result.message}`);
+    process.exit(1);
+  }
+})();

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -31,8 +31,11 @@ export const checkCompatLauncher = async (): Promise<{
     return { status: true, message: '', compatPath: envCmd };
   }
 
-  if (testCommand('wine')) {
-    return { status: true, message: '', compatPath: 'wine' };
+  const candidateCommands = ['wine', 'wine64'];
+  for (const cmd of candidateCommands) {
+    if (testCommand(cmd)) {
+      return { status: true, message: '', compatPath: cmd };
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary
- add script to download or detect Wine
- expose `download:wine` script in `package.json`
- document how to prefetch Wine in the README

## Testing
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_b_686f82d45b208324aa77975afbf866f4