### PR TITLE
Fix news panel height

### DIFF
--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -64,7 +64,7 @@ export function NewsPanel() {
   // itself never becomes scrollable. When the content exceeds this space the
   // inner list will scroll instead.
   return (
-    <Card className="mining-surface flex flex-col max-h-[calc(100dvh-theme(spacing.40)-theme(spacing.12))]">
+    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(100dvh-theme(spacing.40)-theme(spacing.12))]">
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageSquare className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- ensure `NewsPanel` obeys available height by adding `overflow-hidden` and `h-full`

## Testing
- `pnpm build` in `launcher-gui`
- `pnpm lint` *(fails: no-implicit-any and other existing issues)*
- `pnpm lint` at repo root *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f8589b6ec8324919e1ee4ad8ff330