### PR TITLE
Allow loading remote avatars

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -35,7 +35,7 @@ const config: ForgeConfig = {
         ],
       },
       devContentSecurityPolicy:
-        "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app;",
+        "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;",
     }),
     new FusesPlugin({
       version: FuseVersion.V1,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -18,7 +18,7 @@
 
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app;"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;"
     />
     
     <script type="module" crossorigin src="/assets/index.js"></script>


### PR DESCRIPTION
## Summary
- allow remote avatar images in CSP meta tag
- update dev CSP for forge dev server

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f88bf76388324a2f6758c1cc2807b