### PR TITLE
Add trailer video to home page

### DIFF
--- a/launcher-gui/src/components/VideoPanel.tsx
+++ b/launcher-gui/src/components/VideoPanel.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { AspectRatio } from '@/components/ui/aspect-ratio';
+import { PlayCircle } from 'lucide-react';
+
+export function VideoPanel() {
+  return (
+    <Card className="mining-surface flex flex-col overflow-hidden">
+      <CardHeader className="shrink-0">
+        <CardTitle className="text-primary flex items-center gap-2">
+          <PlayCircle className="w-5 h-5" />
+          Game Trailer
+        </CardTitle>
+        <CardDescription className="text-muted-foreground">Watch the latest trailer</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <AspectRatio ratio={16 / 9} className="w-full">
+          <iframe
+            className="w-full h-full rounded-b-lg"
+            src="https://www.youtube.com/embed/1mQacGNeNVA"
+            title="Manic Miners Trailer"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </AspectRatio>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default VideoPanel;

--- a/launcher-gui/src/pages/Home.tsx
+++ b/launcher-gui/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { GameVersionSelector } from '@/components/GameVersionSelector';
 import { NewsPanel } from '@/components/NewsPanel';
 import { CommentsPanel } from '@/components/CommentsPanel';
 import { DownloadProgress } from '@/components/DownloadProgress';
+import { VideoPanel } from '@/components/VideoPanel';
 import { useState } from 'react';
 
 const Home = () => {
@@ -23,7 +24,8 @@ const Home = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main Game Controls */}
-        <div className="lg:col-span-2">
+        <div className="lg:col-span-2 space-y-6">
+          <VideoPanel />
           <GameVersionSelector />
         </div>
 


### PR DESCRIPTION
## Summary
- add `VideoPanel` component
- embed `VideoPanel` in `Home` page

## Testing
- `npx prettier -w launcher-gui/src/components/VideoPanel.tsx launcher-gui/src/pages/Home.tsx`
- `npx eslint launcher-gui/src/components/VideoPanel.tsx launcher-gui/src/pages/Home.tsx` *(fails: Cannot find module '@eslint/eslintrc')*
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f88aea4dc8324aab49b3daf972609