### PR TITLE
Adjust panel heights in GUI

### DIFF
--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -50,7 +50,7 @@ export function CommentsPanel() {
   }
 
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(50dvh-theme(spacing.40)-theme(spacing.12))]">
+    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(60dvh-theme(spacing.40)-theme(spacing.12))]">
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageCircle className="w-5 h-5" />

--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -64,7 +64,7 @@ export function NewsPanel() {
   // itself never becomes scrollable. When the content exceeds this space the
   // inner list will scroll instead.
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(100dvh-theme(spacing.40)-theme(spacing.12))]">
+    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(90dvh-theme(spacing.40)-theme(spacing.12))]">
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageSquare className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- increase comments section's height limit to 60dvh
- reduce news section's height limit to 90dvh

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_b_686f8e5871b48324af0ac65b2fec5505