### PR TITLE
Disable page scroll and add horizontal lists

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -22,7 +22,7 @@ const App = () => (
            * fixed header/navigation bar. This value was slightly increased
            * again to ensure the page content clears the navigation bar.
            */}
-          <main className="flex-1 overflow-y-auto pt-40">
+          <main className="flex-1 overflow-hidden pt-40">
             <Routes>
               <Route path="/" element={<Index />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { MessageCircle } from 'lucide-react';
 
@@ -59,15 +58,15 @@ export function CommentsPanel() {
         <CardDescription className="text-muted-foreground">Recent user feedback</CardDescription>
       </CardHeader>
       <CardContent className="flex-1">
-        <ScrollArea className="h-full pr-2">
-          <div className="space-y-4 pb-2">
+        <div className="h-full pr-2 overflow-x-auto">
+          <div className="flex gap-4 pb-2">
             {comments.length === 0 ? (
               <p className="text-muted-foreground text-center py-4">No comments available</p>
             ) : (
               comments.map(comment => (
                 <div
                   key={comment.id}
-                  className="flex gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 transition-colors"
+                  className="flex gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 transition-colors min-w-[16rem]"
                 >
                   <Avatar className="w-6 h-6">
                     <AvatarImage src={comment.avatarUrl} alt={comment.author} />
@@ -84,7 +83,7 @@ export function CommentsPanel() {
               ))
             )}
           </div>
-        </ScrollArea>
+        </div>
       </CardContent>
     </Card>
   );

--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { MessageSquare, Calendar } from 'lucide-react';
 
 interface LauncherMessage {
@@ -73,16 +72,16 @@ export function NewsPanel() {
         <CardDescription className="text-muted-foreground">Latest updates and announcements</CardDescription>
       </CardHeader>
       <CardContent className="flex-1">
-        {/* The list fills the remaining space and becomes scrollable when needed */}
-        <ScrollArea className="h-full pr-2">
-          <div className="space-y-4 pb-2">
+        {/* Horizontally scroll when the list overflows */}
+        <div className="h-full pr-2 overflow-x-auto">
+          <div className="flex gap-4 pb-2">
             {messages.length === 0 ? (
               <p className="text-muted-foreground text-center py-4">No messages available</p>
             ) : (
               messages.map(message => (
                 <div
                   key={message.id}
-                  className="p-3 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 transition-colors"
+                  className="p-3 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 transition-colors min-w-[16rem]"
                 >
                   <div className="mb-2">
                     <h4 className="font-medium text-secondary-foreground text-sm">{message.title}</h4>
@@ -96,7 +95,7 @@ export function NewsPanel() {
               ))
             )}
           </div>
-        </ScrollArea>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- make the main page container not scroll
- display comments and news horizontally so they can scroll sideways

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f90888eb483248e77e1d035bcac25