### PR TITLE
Fix horizontal layout of news items

### DIFF
--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -74,7 +74,7 @@ export function NewsPanel() {
       <CardContent className="flex-1">
         {/* Horizontally scroll when the list overflows */}
         <div className="h-full pr-2 overflow-x-auto">
-          <div className="flex gap-4 pb-2">
+          <div className="flex gap-4 pb-2 flex-nowrap whitespace-nowrap">
             {messages.length === 0 ? (
               <p className="text-muted-foreground text-center py-4">No messages available</p>
             ) : (


### PR DESCRIPTION
## Summary
- enforce `flex-nowrap` and `whitespace-nowrap` on news list items so the launcher news section always scrolls horizontally

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f94956d948324a2022da56bbb1e3d