### PR TITLE
Adjust padding for taller nav

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -19,10 +19,10 @@ const App = () => (
           <LauncherHeader />
           {/*
            * Provide enough top padding so content isn't hidden beneath the
-           * fixed header/navigation bar. This value was slightly increased
-           * again to ensure the page content clears the navigation bar.
+           * fixed header/navigation bar. This value was increased once more
+           * to account for the slightly taller navigation section.
            */}
-          <main className="flex-1 overflow-hidden pt-40">
+          <main className="flex-1 overflow-hidden pt-44">
             <Routes>
               <Route path="/" element={<Index />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -49,7 +49,7 @@ export function CommentsPanel() {
   }
 
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(60dvh-theme(spacing.40)-theme(spacing.12))]">
+    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(60dvh-theme(spacing.44)-theme(spacing.12))]">
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageCircle className="w-5 h-5" />

--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -63,7 +63,7 @@ export function NewsPanel() {
   // itself never becomes scrollable. When the content exceeds this space the
   // inner list will scroll instead.
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(90dvh-theme(spacing.40)-theme(spacing.12))]">
+    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(90dvh-theme(spacing.44)-theme(spacing.12))]">
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageSquare className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- tweak top padding to match header height
- update comments/news panel max-h calculations

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_686f97c29d808324b874d20e12dc07bf