### PR TITLE
Fix YouTube trailer embed

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -18,7 +18,7 @@
 
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;"
+      content="default-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;"
     />
     
     <script type="module" crossorigin src="/assets/index.js"></script>


### PR DESCRIPTION
## Summary
- allow YouTube video embeds by explicitly allowing the domain in the CSP

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f98beef788324b5c867839d821a7e