### PR TITLE
Fix YouTube iframe CSP

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -35,7 +35,7 @@ const config: ForgeConfig = {
         ],
       },
       devContentSecurityPolicy:
-        "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;",
+        "default-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://manic-launcher.vercel.app; img-src 'self' https: data:;",
     }),
     new FusesPlugin({
       version: FuseVersion.V1,


### PR DESCRIPTION
## Summary
- allow YouTube iframes during development by extending the CSP in `forge.config.ts`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_686f9a2387108324b7881a63728c698f