### PR TITLE
Fix homepage panel heights

### DIFF
--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { MessageCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface Comment {
   id: string;
@@ -11,7 +12,11 @@ interface Comment {
   avatarUrl: string;
 }
 
-export function CommentsPanel() {
+interface CommentsPanelProps {
+  className?: string;
+}
+
+export function CommentsPanel({ className }: CommentsPanelProps) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -48,11 +53,10 @@ export function CommentsPanel() {
     );
   }
 
-  // Restrict the card's height based on the available viewport so the page
-  // itself never becomes scrollable. When the content exceeds this space the
-  // inner list will scroll instead.
+  // Allow the card to stretch within its container and let the inner list
+  // scroll independently when it exceeds the available space.
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(60dvh-theme(spacing.44)-theme(spacing.12))]">
+    <Card className={cn('mining-surface flex flex-col h-full overflow-hidden', className)}>
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageCircle className="w-5 h-5" />

--- a/launcher-gui/src/components/NewsPanel.tsx
+++ b/launcher-gui/src/components/NewsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { MessageSquare, Calendar } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface LauncherMessage {
   id: number;
@@ -9,7 +10,11 @@ interface LauncherMessage {
   date: string;
 }
 
-export function NewsPanel() {
+interface NewsPanelProps {
+  className?: string;
+}
+
+export function NewsPanel({ className }: NewsPanelProps) {
   const [messages, setMessages] = useState<LauncherMessage[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -59,11 +64,10 @@ export function NewsPanel() {
     );
   }
 
-  // Restrict the card's height based on the available viewport so the page
-  // itself never becomes scrollable. When the content exceeds this space the
-  // inner list will scroll instead.
+  // Allow the card to stretch within its container and let the inner list
+  // scroll independently when it exceeds the available space.
   return (
-    <Card className="mining-surface flex flex-col h-full overflow-hidden max-h-[calc(90dvh-theme(spacing.44)-theme(spacing.12))]">
+    <Card className={cn('mining-surface flex flex-col h-full overflow-hidden', className)}>
       <CardHeader className="shrink-0">
         <CardTitle className="text-primary flex items-center gap-2">
           <MessageSquare className="w-5 h-5" />

--- a/launcher-gui/src/pages/Home.tsx
+++ b/launcher-gui/src/pages/Home.tsx
@@ -9,7 +9,7 @@ const Home = () => {
   const [isDownloading, setIsDownloading] = useState(false);
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="container mx-auto p-6 space-y-6 h-full flex flex-col">
       {isDownloading && (
         <DownloadProgress
           isActive={isDownloading}
@@ -22,17 +22,17 @@ const Home = () => {
         />
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-full">
         {/* Main Game Controls */}
-        <div className="lg:col-span-2 space-y-6">
+        <div className="lg:col-span-2 flex flex-col space-y-6 h-full">
           <GameVersionSelector />
-          <CommentsPanel />
+          <CommentsPanel className="flex-1" />
         </div>
 
         {/* Sidebar */}
-        <div className="space-y-6">
+        <div className="flex flex-col space-y-6 h-full">
           <VideoPanel />
-          <NewsPanel />
+          <NewsPanel className="flex-1" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure news and comments panels stretch to fill their columns
- allow passing CSS class names to `NewsPanel` and `CommentsPanel`
- adjust `Home` layout to use the new flexible panels

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_686f9a0052748324b47c6933e6946a5e