### PR TITLE
Remove hover from Game Version card

### DIFF
--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -72,7 +72,7 @@ export function GameVersionSelector() {
 
   if (loading) {
     return (
-      <Card className="mining-surface energy-glow">
+      <Card className="mining-surface energy-glow-static">
         <CardHeader>
           <CardTitle className="text-primary">Loading Versions...</CardTitle>
         </CardHeader>
@@ -87,7 +87,7 @@ export function GameVersionSelector() {
   }
 
   return (
-    <Card className="mining-surface energy-glow">
+    <Card className="mining-surface energy-glow-static">
       <CardHeader>
         <CardTitle className="text-primary flex items-center gap-2">
           <Zap className="w-5 h-5" />

--- a/launcher-gui/src/index.css
+++ b/launcher-gui/src/index.css
@@ -127,6 +127,12 @@ All colors MUST be HSL.
     transition: var(--transition-energy);
   }
 
+  /* Same appearance without the hover animation */
+  .energy-glow-static {
+    box-shadow: var(--shadow-energy);
+    transition: var(--transition-energy);
+  }
+
   .energy-glow:hover {
     box-shadow: var(--shadow-glow);
     transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- disable hover animation for the Game Version card
- introduce `energy-glow-static` style to keep the glow without hover

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_686f9e05936c8324afec30439ffb1a73