### PR TITLE
Add Proton support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 
 - Node.js 20 or later
 - pnpm package manager
-- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, it searches for common Wine executables such as `wine` or `wine64`.
+- On Linux and macOS a Windows compatibility layer such as **Proton** or **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable, falling back to `proton`, `wine` or `wine64` if detected on the system.
 
-Automatic Wine download is supported on Linux and macOS. On macOS the launcher attempts to install Wine via Homebrew if it is not already available. You can run `pnpm run download:wine` on Linux to prefetch the Wine bundle before packaging or launching.
+Automatic Wine download is supported on Linux and macOS if Proton is not detected. On macOS the launcher attempts to install Wine via Homebrew if it is not already available. You can run `pnpm run download:wine` on Linux to prefetch the Wine bundle before packaging or launching.
 
 ## Development
 

--- a/scripts/downloadWine.ts
+++ b/scripts/downloadWine.ts
@@ -5,7 +5,7 @@ import { checkCompatLauncher } from '../src/functions/checkCompatLauncher';
   if (result.status) {
     console.log(`Compatibility layer available at: ${result.compatPath || 'system default'}`);
   } else {
-    console.error(`Failed to set up Wine: ${result.message}`);
+    console.error(`Failed to set up compatibility layer: ${result.message}`);
     process.exit(1);
   }
 })();

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -9,8 +9,8 @@ const DEFAULT_WINE_URL =
   process.env.WINE_DOWNLOAD_URL || 'https://dl.winehq.org/wine-builds/macosx/pool/portable-winehq-stable-5.0-osx64.tar.gz';
 
 /**
- * Ensures a compatibility launcher (Wine or custom) is available.
- * If not found, attempts to download a portable Wine distribution.
+ * Ensures a compatibility launcher (Proton, Wine or custom) is available.
+ * If none is found, attempts to download a portable Wine distribution.
  */
 export const checkCompatLauncher = async (): Promise<{
   status: boolean;
@@ -18,14 +18,14 @@ export const checkCompatLauncher = async (): Promise<{
   compatPath?: string;
 }> => {
   if (process.platform === 'win32') {
-    return { status: true, message: 'Windows does not require Wine.' };
+    return { status: true, message: 'Windows does not require Proton or Wine.' };
   }
 
-  // On macOS first try user-provided or system Wine. If none exists, attempt to
+  // On macOS first try user-provided or system Proton/Wine. If none exists, attempt to
   // install Wine via Homebrew for a smoother out-of-box experience.
   if (process.platform === 'darwin') {
     const envCmd = process.env.COMPAT_LAUNCHER;
-    const candidateCommands = envCmd ? [envCmd, 'wine64', 'wine'] : ['wine64', 'wine'];
+    const candidateCommands = envCmd ? [envCmd, 'proton', 'wine64', 'wine'] : ['proton', 'wine64', 'wine'];
     let compatCmd = pickFirstWorking(candidateCommands);
     if (compatCmd) {
       return { status: true, message: '', compatPath: compatCmd };
@@ -37,7 +37,7 @@ export const checkCompatLauncher = async (): Promise<{
       if (brewInstall.status === 0) {
         compatCmd = pickFirstWorking(candidateCommands);
         if (compatCmd) {
-          return { status: true, message: 'Wine installed via Homebrew.', compatPath: compatCmd };
+          return { status: true, message: 'Compatibility layer installed via Homebrew.', compatPath: compatCmd };
         }
       }
       return {
@@ -49,7 +49,7 @@ export const checkCompatLauncher = async (): Promise<{
     return {
       status: false,
       message:
-        'Wine is required on macOS. Homebrew was not found for automatic install. Please install Wine manually or set COMPAT_LAUNCHER.',
+        'A compatibility layer (Proton or Wine) is required on macOS. Homebrew was not found for automatic install. Please install Wine or Proton manually or set COMPAT_LAUNCHER.',
     };
   }
 
@@ -70,7 +70,7 @@ export const checkCompatLauncher = async (): Promise<{
     return { status: true, message: '', compatPath: envCmd };
   }
 
-  const candidateCommands = ['wine', 'wine64'];
+  const candidateCommands = ['proton', 'wine', 'wine64'];
   for (const cmd of candidateCommands) {
     if (testCommand(cmd)) {
       return { status: true, message: '', compatPath: cmd };
@@ -105,7 +105,7 @@ export const checkCompatLauncher = async (): Promise<{
     await fs.chmod(wineExe, 0o755);
 
     if (testCommand(wineExe)) {
-      return { status: true, message: 'Wine downloaded.', compatPath: wineExe };
+      return { status: true, message: 'Wine downloaded as compatibility layer.', compatPath: wineExe };
     }
 
     return { status: false, message: 'Wine download failed to run.' };

--- a/src/functions/launchExecutable.ts
+++ b/src/functions/launchExecutable.ts
@@ -17,9 +17,10 @@ export const launchExecutable = ({
     const startTime = Date.now();
 
     const useCompat = process.platform !== 'win32';
-    const compatCmd = compatLauncher || process.env.COMPAT_LAUNCHER || 'wine';
+    const compatCmd = compatLauncher || process.env.COMPAT_LAUNCHER || 'proton';
     const spawnCmd = useCompat ? compatCmd : executablePath;
-    const spawnArgs = useCompat ? [executablePath] : [];
+    const isProton = useCompat && compatCmd.toLowerCase().includes('proton');
+    const spawnArgs = useCompat ? (isProton ? ['run', executablePath] : [executablePath]) : [];
 
     const child = spawn(spawnCmd, spawnArgs, {
       detached: true,


### PR DESCRIPTION
## Summary
- support Proton as the default compatibility layer
- check for Proton before Wine
- update launcher invocation to call `proton run` when needed
- clarify compatibility layer requirements in the README
- tweak download script output

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_687040e567048324abcb8938f06e1dee