### PR TITLE
Default to Proton only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 
 - Node.js 20 or later
 - pnpm package manager
-- On Linux and macOS a Windows compatibility layer such as **Wine** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable. If no compatible command is found, it searches for common Wine executables such as `wine` or `wine64`.
+- On Linux and macOS a Windows compatibility layer using **Proton** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable or a Proton installation detected on the system. Proton is an open-source compatibility tool built on Wine for running Windows games through Steam [[Proton README](https://github.com/ValveSoftware/Proton)].
 
-Automatic Wine download is supported on Linux and macOS. On macOS the launcher attempts to install Wine via Homebrew if it is not already available. You can run `pnpm run download:wine` on Linux to prefetch the Wine bundle before packaging or launching.
+The launcher automatically downloads the latest Proton GE build on Linux if no suitable Proton is found. Proton currently has no official macOS distribution, so macOS users must supply their own Proton build (for example community ports). Run `pnpm run check:proton` to verify that Proton is available or to trigger the download.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "update-git-url": "node scripts/updatePackageJson.js",
     "generate:assets": "ts-node scripts/generateAssets.ts",
-    "download:wine": "ts-node scripts/downloadWine.ts"
+    "check:proton": "ts-node scripts/checkProton.ts"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.1",

--- a/scripts/checkProton.ts
+++ b/scripts/checkProton.ts
@@ -5,7 +5,7 @@ import { checkCompatLauncher } from '../src/functions/checkCompatLauncher';
   if (result.status) {
     console.log(`Compatibility layer available at: ${result.compatPath || 'system default'}`);
   } else {
-    console.error(`Failed to set up Wine: ${result.message}`);
+    console.error(`Failed to set up Proton: ${result.message}`);
     process.exit(1);
   }
 })();

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -5,12 +5,56 @@ import { getDirectories } from './fetchDirectories';
 import { downloadFile } from './downloadFile';
 import { extractTarGz, flattenSingleSubdirectory } from './unpackHelpers';
 
-const DEFAULT_WINE_URL =
-  process.env.WINE_DOWNLOAD_URL || 'https://dl.winehq.org/wine-builds/macosx/pool/portable-winehq-stable-5.0-osx64.tar.gz';
+const PROTON_GE_RELEASE_API = 'https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest';
+
+async function fetchLatestProtonUrl(): Promise<string | undefined> {
+  try {
+    const response = await fetch(PROTON_GE_RELEASE_API, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as any;
+    const asset = (data.assets as any[]).find(a => typeof a.name === 'string' && a.name.endsWith('.tar.gz'));
+    return asset?.browser_download_url;
+  } catch {
+    return undefined;
+  }
+}
+
+async function findProtonFromSteam(): Promise<string | undefined> {
+  const home = process.env.HOME;
+  if (!home) return undefined;
+
+  const possibleDirs = [
+    path.join(home, '.steam/steam/steamapps/common'),
+    path.join(home, '.local/share/Steam/steamapps/common'),
+    path.join(home, 'Library/Application Support/Steam/steamapps/common'),
+  ];
+
+  for (const dir of possibleDirs) {
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.startsWith('Proton')) {
+          const candidate = path.join(dir, entry.name, 'proton');
+          try {
+            await fs.access(candidate);
+            return candidate;
+          } catch {
+            // continue searching
+          }
+        }
+      }
+    } catch {
+      // ignore if directory doesn't exist
+    }
+  }
+
+  return undefined;
+}
 
 /**
- * Ensures a compatibility launcher (Wine or custom) is available.
- * If not found, attempts to download a portable Wine distribution.
+ * Ensures a Proton launcher is available.
  */
 export const checkCompatLauncher = async (): Promise<{
   status: boolean;
@@ -18,51 +62,12 @@ export const checkCompatLauncher = async (): Promise<{
   compatPath?: string;
 }> => {
   if (process.platform === 'win32') {
-    return { status: true, message: 'Windows does not require Wine.' };
-  }
-
-  // On macOS first try user-provided or system Wine. If none exists, attempt to
-  // install Wine via Homebrew for a smoother out-of-box experience.
-  if (process.platform === 'darwin') {
-    const envCmd = process.env.COMPAT_LAUNCHER;
-    const candidateCommands = envCmd ? [envCmd, 'wine64', 'wine'] : ['wine64', 'wine'];
-    let compatCmd = pickFirstWorking(candidateCommands);
-    if (compatCmd) {
-      return { status: true, message: '', compatPath: compatCmd };
-    }
-
-    const brewCheck = spawnSync('brew', ['--version'], { stdio: 'ignore' });
-    if (brewCheck.status === 0) {
-      const brewInstall = spawnSync('brew', ['install', '--cask', 'wine-stable'], { stdio: 'ignore' });
-      if (brewInstall.status === 0) {
-        compatCmd = pickFirstWorking(candidateCommands);
-        if (compatCmd) {
-          return { status: true, message: 'Wine installed via Homebrew.', compatPath: compatCmd };
-        }
-      }
-      return {
-        status: false,
-        message: 'Attempted to install Wine via Homebrew but it was not detected afterwards.',
-      };
-    }
-
-    return {
-      status: false,
-      message:
-        'Wine is required on macOS. Homebrew was not found for automatic install. Please install Wine manually or set COMPAT_LAUNCHER.',
-    };
+    return { status: true, message: 'Windows does not require Proton.' };
   }
 
   function testCommand(cmd: string): boolean {
     const result = spawnSync(cmd, ['--version'], { stdio: 'ignore' });
-    return !result.error && result.status === 0;
-  }
-
-  function pickFirstWorking(commands: string[]): string | undefined {
-    for (const c of commands) {
-      if (testCommand(c)) return c;
-    }
-    return undefined;
+    return !result.error && result.status !== null;
   }
 
   const envCmd = process.env.COMPAT_LAUNCHER;
@@ -70,47 +75,62 @@ export const checkCompatLauncher = async (): Promise<{
     return { status: true, message: '', compatPath: envCmd };
   }
 
-  const candidateCommands = ['wine', 'wine64'];
+  const candidateCommands = ['proton'];
   for (const cmd of candidateCommands) {
     if (testCommand(cmd)) {
       return { status: true, message: '', compatPath: cmd };
     }
   }
 
-  try {
-    const { directories } = await getDirectories();
-    const wineDir = path.join(directories.launcherInstallPath, 'wine');
-    const wineExe = path.join(wineDir, 'wine');
-    try {
-      await fs.access(wineExe);
-      if (testCommand(wineExe)) {
-        return { status: true, message: '', compatPath: wineExe };
-      }
-    } catch {
-      // Ignore errors if the bundled Wine executable is not present
-    }
-
-    const archivePath = path.join(directories.launcherInstallPath, 'wine.tar.gz');
-    const downloadResult = await downloadFile({
-      downloadUrl: DEFAULT_WINE_URL,
-      filePath: archivePath,
-    });
-    if (!downloadResult.status) {
-      return { status: false, message: downloadResult.message };
-    }
-
-    await extractTarGz({ filePath: archivePath, targetPath: wineDir });
-    await flattenSingleSubdirectory(wineDir);
-    await fs.unlink(archivePath);
-    await fs.chmod(wineExe, 0o755);
-
-    if (testCommand(wineExe)) {
-      return { status: true, message: 'Wine downloaded.', compatPath: wineExe };
-    }
-
-    return { status: false, message: 'Wine download failed to run.' };
-  } catch (err) {
-    const error = err as Error;
-    return { status: false, message: `Wine setup failed: ${error.message}` };
+  const steamProton = await findProtonFromSteam();
+  if (steamProton) {
+    return { status: true, message: '', compatPath: steamProton };
   }
+
+  if (process.platform === 'linux') {
+    try {
+      const { directories } = await getDirectories();
+      const protonDir = path.join(directories.launcherInstallPath, 'proton');
+      const protonExe = path.join(protonDir, 'proton');
+
+      try {
+        await fs.access(protonExe);
+        if (testCommand(protonExe)) {
+          return { status: true, message: '', compatPath: protonExe };
+        }
+      } catch {
+        // no bundled Proton yet
+      }
+
+      const downloadUrl = process.env.PROTON_DOWNLOAD_URL || (await fetchLatestProtonUrl());
+      if (!downloadUrl) {
+        return { status: false, message: 'Failed to determine Proton download URL.' };
+      }
+
+      const archivePath = path.join(directories.launcherInstallPath, 'proton.tar.gz');
+      const downloadResult = await downloadFile({ downloadUrl, filePath: archivePath });
+      if (!downloadResult.status) {
+        return { status: false, message: downloadResult.message };
+      }
+
+      await extractTarGz({ filePath: archivePath, targetPath: protonDir });
+      await flattenSingleSubdirectory(protonDir);
+      await fs.unlink(archivePath);
+      await fs.chmod(protonExe, 0o755);
+
+      if (testCommand(protonExe)) {
+        return { status: true, message: 'Proton downloaded.', compatPath: protonExe };
+      }
+
+      return { status: false, message: 'Proton download failed to run.' };
+    } catch (err) {
+      const error = err as Error;
+      return { status: false, message: `Proton setup failed: ${error.message}` };
+    }
+  }
+
+  return {
+    status: false,
+    message: 'Proton was not detected. Please install Proton and set COMPAT_LAUNCHER or ensure it is on your PATH.',
+  };
 };

--- a/src/functions/launchExecutable.ts
+++ b/src/functions/launchExecutable.ts
@@ -17,9 +17,10 @@ export const launchExecutable = ({
     const startTime = Date.now();
 
     const useCompat = process.platform !== 'win32';
-    const compatCmd = compatLauncher || process.env.COMPAT_LAUNCHER || 'wine';
+    const compatCmd = compatLauncher || process.env.COMPAT_LAUNCHER || 'proton';
     const spawnCmd = useCompat ? compatCmd : executablePath;
-    const spawnArgs = useCompat ? [executablePath] : [];
+    const isProton = useCompat && compatCmd.toLowerCase().includes('proton');
+    const spawnArgs = useCompat ? (isProton ? ['run', executablePath] : [executablePath]) : [];
 
     const child = spawn(spawnCmd, spawnArgs, {
       detached: true,


### PR DESCRIPTION
## Summary
- drop Wine download logic and remove Wine fallback
- rename helper script to `checkProton.ts`
- update package.json script and docs for Proton-only support
- automatically download the latest Proton GE build on Linux

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_687040e567048324abcb8938f06e1dee