### PR TITLE
Improve Proton detection on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is an Electron-based launcher for the game **Manic Miners**. The la
 - pnpm package manager
 - On Linux and macOS a Windows compatibility layer using **Proton** is required to run the Windows game binaries. The launcher will attempt to use the command from the `COMPAT_LAUNCHER` environment variable or a Proton installation detected on the system. Proton is an open-source compatibility tool built on Wine for running Windows games through Steam [[Proton README](https://github.com/ValveSoftware/Proton)].
 
-The launcher automatically downloads the latest Proton GE build on Linux if no suitable Proton is found. The download is verified against the SHA-512 checksum published with each release. Proton currently has no official macOS distribution, so macOS users must supply their own Proton build (for example community ports). Run `pnpm run check:proton` to verify that Proton is available or to trigger the download.
+The launcher automatically downloads the latest Proton GE build on Linux if no suitable Proton is found. The download is verified against the SHA-512 checksum published with each release. Proton currently has no official macOS distribution, so macOS users must supply their own Proton build (for example community ports). The launcher will now attempt to locate Proton from common macOS installation paths in addition to using `COMPAT_LAUNCHER`. Run `pnpm run check:proton` to verify that Proton is available or to trigger the download on Linux.
 
 ## Development
 

--- a/src/functions/checkCompatLauncher.ts
+++ b/src/functions/checkCompatLauncher.ts
@@ -80,6 +80,26 @@ async function findProtonFromSteam(): Promise<string | undefined> {
   return undefined;
 }
 
+async function findProtonOnMac(): Promise<string | undefined> {
+  const home = process.env.HOME;
+  const possiblePaths = ['/Applications/Proton.app/Contents/MacOS/proton', '/Applications/Proton\u2010GE.app/Contents/MacOS/proton'];
+  if (home) {
+    possiblePaths.push(path.join(home, 'Applications/Proton.app/Contents/MacOS/proton'));
+    possiblePaths.push(path.join(home, 'Applications/Proton\u2010GE.app/Contents/MacOS/proton'));
+  }
+
+  for (const p of possiblePaths) {
+    try {
+      await fs.access(p);
+      return p;
+    } catch {
+      // ignore if path doesn't exist
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Ensures a Proton launcher is available.
  */
@@ -112,6 +132,13 @@ export const checkCompatLauncher = async (): Promise<{
   const steamProton = await findProtonFromSteam();
   if (steamProton) {
     return { status: true, message: '', compatPath: steamProton };
+  }
+
+  if (process.platform === 'darwin') {
+    const macProton = await findProtonOnMac();
+    if (macProton) {
+      return { status: true, message: '', compatPath: macProton };
+    }
   }
 
   if (process.platform === 'linux') {


### PR DESCRIPTION
## Summary
- detect Proton from common macOS paths in `checkCompatLauncher`
- document macOS Proton detection in README

## Testing
- `pnpm run lint`
- `pnpm run check:proton` *(fails: Failed to determine Proton download URL)*

------
https://chatgpt.com/codex/tasks/task_b_6870897a15e48324867fd0ef3e61aad2