### PR TITLE
Implement masonry layout for comments

### DIFF
--- a/launcher-gui/package.json
+++ b/launcher-gui/package.json
@@ -52,6 +52,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-masonry-css": "^1.0.16",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",

--- a/launcher-gui/pnpm-lock.yaml
+++ b/launcher-gui/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       react-hook-form:
         specifier: ^7.53.0
         version: 7.60.0(react@18.3.1)
+      react-masonry-css:
+        specifier: ^1.0.16
+        version: 1.0.16(react@18.3.1)
       react-resizable-panels:
         specifier: ^2.1.3
         version: 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2287,6 +2290,11 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-masonry-css@1.0.16:
+    resolution: {integrity: sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4555,6 +4563,10 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
+
+  react-masonry-css@1.0.16(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.23)(react@18.3.1):
     dependencies:

--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import Masonry from 'react-masonry-css';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -65,15 +66,12 @@ export function CommentsPanel({ className }: CommentsPanelProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto pr-2 min-h-0">
-        <div className="grid grid-cols-2 gap-4 pb-2">
+        <Masonry breakpointCols={2} className="my-masonry-grid pb-2" columnClassName="my-masonry-grid_column">
           {comments.length === 0 ? (
             <p className="text-muted-foreground text-center py-4">No comments available</p>
           ) : (
             comments.map(comment => {
-              const truncated =
-                comment.text.length > 350
-                  ? `${comment.text.slice(0, 350)}...`
-                  : comment.text;
+              const truncated = comment.text.length > 500 ? `${comment.text.slice(0, 500)}...` : comment.text;
               const isHovered = hoveredId === comment.id;
               return (
                 <div
@@ -91,10 +89,7 @@ export function CommentsPanel({ className }: CommentsPanelProps) {
                       <span className="font-medium text-secondary-foreground text-sm">{comment.author}</span>
                       <span className="text-xs text-muted-foreground">{new Date(comment.date).toLocaleDateString()}</span>
                     </div>
-                    <p
-                      className="text-xs text-muted-foreground break-words"
-                      title={comment.text}
-                    >
+                    <p className="text-xs text-muted-foreground break-words" title={comment.text}>
                       {isHovered ? comment.text : truncated}
                     </p>
                   </div>
@@ -102,7 +97,7 @@ export function CommentsPanel({ className }: CommentsPanelProps) {
               );
             })
           )}
-        </div>
+        </Masonry>
       </CardContent>
     </Card>
   );

--- a/launcher-gui/src/index.css
+++ b/launcher-gui/src/index.css
@@ -180,3 +180,17 @@ All colors MUST be HSL.
     -webkit-app-region: no-drag;
   }
 }
+
+/* Masonry layout classes for react-masonry-css */
+.my-masonry-grid {
+  display: flex;
+  margin-left: -1rem; /* gutter size offset */
+  width: auto;
+}
+.my-masonry-grid_column {
+  padding-left: 1rem; /* gutter size */
+  background-clip: padding-box;
+}
+.my-masonry-grid_column > div {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- display comments using `react-masonry-css` for balanced columns
- define masonry CSS classes
- add `react-masonry-css` dependency
- truncate comments at 500 characters and expand on hover

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687099f3fc0c8324aee4aa884a54686c