### PR TITLE
Expand draggable header area

### DIFF
--- a/launcher-gui/src/components/LauncherHeader.tsx
+++ b/launcher-gui/src/components/LauncherHeader.tsx
@@ -4,7 +4,7 @@ import { Navigation } from './Navigation';
 
 export function LauncherHeader() {
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 border-b border-border mining-surface">
+    <header className="drag fixed top-0 left-0 right-0 z-50 border-b border-border mining-surface">
       <div className="container mx-auto p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- allow dragging on the entire header section, not only the nav bar

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6870a04603688324be2c20be875b69c2