### PR TITLE
Remove unused tar extraction helper

### DIFF
--- a/src/functions/unpackHelpers.ts
+++ b/src/functions/unpackHelpers.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import StreamZip from 'node-stream-zip';
-import tar from 'tar';
 
 /**
  * Validates a zip entry name against a target base directory to
@@ -84,9 +83,3 @@ export async function flattenSingleSubdirectory(targetPath: string): Promise<voi
   }
 }
 
-/**
- * Extracts a .tar.gz archive into the target directory.
- */
-export async function extractTarGz({ filePath, targetPath }: { filePath: string; targetPath: string }): Promise<void> {
-  await tar.x({ file: filePath, cwd: targetPath, strict: true });
-}


### PR DESCRIPTION
## Summary
- clean up `unpackHelpers.ts` by removing the unused `extractTarGz`

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6870a5438c10832488d03b7f983ebe53