### PR TITLE
Remove tests step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run lint
         run: pnpm run lint
-      - name: Run tests
-        run: pnpm test
       - name: Build Electron app
         run: pnpm run make


### PR DESCRIPTION
## Summary
- delete the failing test step from GitHub Actions workflow

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6870a57e35a88324bc699bdac2c090b2