### PR TITLE
Integrate itch.io update check

### DIFF
--- a/src/functions/checkItchUpdate.ts
+++ b/src/functions/checkItchUpdate.ts
@@ -1,0 +1,71 @@
+import fs from 'fs/promises';
+import path from 'path';
+import StreamZip from 'node-stream-zip';
+import { downloadGame } from 'itchio-downloader';
+import { getDirectories } from './fetchDirectories';
+import { extractZipEntries, flattenSingleSubdirectory } from './unpackHelpers';
+import Store from 'electron-store';
+
+const ITCH_URL = 'https://baraklava.itch.io/manic-miners';
+const VERSION_REGEX = /Last updated:\s*\d{4}-\d{2}-\d{2} \(([^)]+)\)/i;
+
+export async function checkItchUpdate(updateStatus?: (s: { status: string; progress: number }) => void): Promise<void> {
+  try {
+    const page = await fetch(ITCH_URL).then(r => r.text());
+    const match = page.match(VERSION_REGEX);
+    if (!match) return;
+
+    const version = match[1].replace(/[^0-9.]/g, '');
+    const identifier = `ManicMiners-Baraklava-V${version}`;
+
+    const store = new Store();
+    const lastVersion = store.get('last-known-version');
+    if (lastVersion === version) return;
+
+    const { directories } = await getDirectories();
+    const installDir = directories.launcherInstallPath;
+    const cacheDir = directories.launcherCachePath;
+    const installPath = path.join(installDir, identifier);
+
+    const exists = await fs
+      .access(installPath)
+      .then(() => true)
+      .catch(() => false);
+    if (exists) {
+      store.set('last-known-version', version);
+      return;
+    }
+
+    if (updateStatus) updateStatus({ status: 'Downloading latest version...', progress: 5 });
+    const result = (await downloadGame({
+      itchGameUrl: ITCH_URL,
+      desiredFileName: identifier,
+      downloadDirectory: cacheDir,
+      onProgress: info => {
+        if (info.totalBytes && updateStatus) {
+          const pct = Math.floor((info.bytesReceived / info.totalBytes) * 40);
+          updateStatus({ status: 'Downloading latest version...', progress: pct });
+        }
+      },
+    })) as { status: boolean; message: string; filePath?: string };
+
+    if (!result.status || !result.filePath) throw new Error(result.message);
+
+    await fs.mkdir(installPath, { recursive: true });
+    const zip = new StreamZip.async({ file: result.filePath });
+    await extractZipEntries({
+      zip,
+      targetPath: installPath,
+      updateStatus: s => {
+        if (updateStatus) updateStatus({ status: s.status, progress: 40 + (s.progress ?? 0) * 0.6 });
+      },
+    });
+    await zip.close();
+    await flattenSingleSubdirectory(installPath);
+
+    store.set('last-known-version', version);
+    if (updateStatus) updateStatus({ status: 'Update installed', progress: 100 });
+  } catch (err) {
+    console.error('Failed to check Itch.io update:', err);
+  }
+}

--- a/src/functions/unpackHelpers.ts
+++ b/src/functions/unpackHelpers.ts
@@ -82,4 +82,3 @@ export async function flattenSingleSubdirectory(targetPath: string): Promise<voi
     await fs.promises.rmdir(nestedDir);
   }
 }
-

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import { setupUrlHandler } from './ipcHandlers/setupUrlHandler';
 import { setupPlaySoundHandler } from './ipcHandlers/setupPlaySoundHandler';
 import { setupSettingsHandlers } from './ipcHandlers/setupSettingsHandlers';
 import { setupWindowControlHandlers } from './ipcHandlers/setupWindowControlHandlers';
+import { checkItchUpdate } from '../functions/checkItchUpdate';
 
 // Disable hardware acceleration to avoid GPU-related errors in some environments
 app.disableHardwareAcceleration();
@@ -20,8 +21,9 @@ const userDataPath = path.join(app.getPath('home'), '.manic-miners-launcher');
 app.setPath('userData', userDataPath);
 
 const startApp = (): void => {
-  app.on('ready', () => {
+  app.on('ready', async () => {
     setupDirectoryHandler();
+    await checkItchUpdate();
     createWindow();
     setupVersionHandlers();
     setupGameLaunchHandlers();


### PR DESCRIPTION
## Summary
- introduce `checkItchUpdate` to download new builds from itch.io directly
- call the new function when the app starts

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6870a7301ad48324a1e7efa2d0b1623c