### PR TITLE
Remove tooltip from comments

### DIFF
--- a/launcher-gui/src/components/CommentsPanel.tsx
+++ b/launcher-gui/src/components/CommentsPanel.tsx
@@ -89,9 +89,7 @@ export function CommentsPanel({ className }: CommentsPanelProps) {
                       <span className="font-medium text-secondary-foreground text-sm">{comment.author}</span>
                       <span className="text-xs text-muted-foreground">{new Date(comment.date).toLocaleDateString()}</span>
                     </div>
-                    <p className="text-xs text-muted-foreground break-words" title={comment.text}>
-                      {isHovered ? comment.text : truncated}
-                    </p>
+                    <p className="text-xs text-muted-foreground break-words">{isHovered ? comment.text : truncated}</p>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## Summary
- update comments to remove HTML `title` attribute so hovering doesn't show a tooltip

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_6870cd7c8e2c83248ade86a006597b04