### PR TITLE
Use archived versions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 This project is an Electron-based launcher for the game **Manic Miners**. The launcher downloads and manages multiple game versions and provides a simple user interface for starting the game.
 
+The launcher now retrieves its list of available versions from
+`https://manic-launcher.vercel.app/api/versions/archived`, which contains
+archived releases of Manic Miners.
+
 ## Requirements
 
 - Node.js 20 or later
 - pnpm package manager
-This launcher currently supports running the game only on Windows systems.
+  This launcher currently supports running the game only on Windows systems.
 
 ## Development
 

--- a/src/api/fetchVersions.ts
+++ b/src/api/fetchVersions.ts
@@ -1,7 +1,7 @@
 import { fetchServerData } from './fetchServerData';
 import { Version, Versions, VersionSelectionType } from './versionTypes';
 
-export async function fetchVersions({ versionType = 'all' }: { versionType?: VersionSelectionType }): Promise<Versions> {
+export async function fetchVersions({ versionType = 'archived' }: { versionType?: VersionSelectionType }): Promise<Versions> {
   const formattedVersionType = `versions.${versionType}`;
 
   const { data, status, message } = await fetchServerData({

--- a/src/api/versionTypes.ts
+++ b/src/api/versionTypes.ts
@@ -19,7 +19,7 @@ export interface Version {
   detailsUrl: string;
   description: string;
 }
-export type VersionSelectionType = 'all' | 'latest' | 'past' | 'experimental';
+export type VersionSelectionType = 'all' | 'latest' | 'past' | 'experimental' | 'archived';
 
 export interface Versions {
   versions: Version[];

--- a/src/functions/downloadVersion.ts
+++ b/src/functions/downloadVersion.ts
@@ -18,7 +18,7 @@ export const downloadVersion = async ({
 
   try {
     updateStatus({ status: 'Fetching version index...', progress: 7 });
-    const versionData = await fetchVersions({});
+    const versionData = await fetchVersions({ versionType: 'archived' });
     const versions = versionData.versions; // Ensure this is an array
 
     updateStatus({ progress: 5 });

--- a/src/functions/fetchInstalledVersions.ts
+++ b/src/functions/fetchInstalledVersions.ts
@@ -23,7 +23,7 @@ export const fetchInstalledVersions = async (): Promise<{
       throw new Error(dirMessage);
     }
 
-    const versionsData: Versions = await fetchVersions({ versionType: 'all' });
+    const versionsData: Versions = await fetchVersions({ versionType: 'archived' });
     const filesAndDirs = await fs.readdir(launcherInstallPath);
     const dirStats = await Promise.all(filesAndDirs.map(name => fs.stat(path.join(launcherInstallPath, name))));
     const dirs = filesAndDirs.filter((_, index) => dirStats[index].isDirectory());

--- a/src/functions/unpackVersion.ts
+++ b/src/functions/unpackVersion.ts
@@ -21,7 +21,7 @@ export const unpackVersion = async ({
   message: string;
 }> => {
   if (updateStatus) updateStatus({ status: 'Starting the unpacking process...', progress: 60 });
-  const { versions } = await fetchVersions({ versionType: 'all' });
+  const { versions } = await fetchVersions({ versionType: 'archived' });
 
   const versionToUnpack = versions.find(v => v.identifier === versionIdentifier) || versions[0];
   if (!versionToUnpack) {

--- a/src/main/ipcHandlers/setupVersionHandlers.ts
+++ b/src/main/ipcHandlers/setupVersionHandlers.ts
@@ -28,7 +28,7 @@ export const setupVersionHandlers = () => {
 };
 
 const getVersionDetails = async () => {
-  const versionData = await fetchVersions({ versionType: 'all' });
+  const versionData = await fetchVersions({ versionType: 'archived' });
   const installedVersionsResult = await fetchInstalledVersions();
 
   const enhancedVersions = versionData.versions.map(version => {


### PR DESCRIPTION
## Summary
- default to archived versions in fetchVersions
- adjust version handlers and utilities to use the new endpoint
- document the archived endpoint in README

## Testing
- `pnpm lint`
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_b_68715dd88b6c8324bf9b765c94f0a5dd