### PR TITLE
Fix default version in selector

### DIFF
--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -67,9 +67,9 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd }: GameVers
         });
         setVersions(sorted);
         if (data.defaultVersion) {
-          setSelectedVersion(data.defaultVersion.identifier);
+          setSelectedVersion(data.defaultVersion.version);
         } else if (sorted.length > 0) {
-          setSelectedVersion(sorted[0].identifier || sorted[0].version);
+          setSelectedVersion(sorted[0].version);
         }
         const installed = new Set(sorted.filter((v: any) => v.directory).map(v => v.version));
         setInstalledVersions(installed);


### PR DESCRIPTION
## Summary
- set game version selector to pick the newest version by default

## Testing
- `pnpm lint` *(fails: 2129 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6871f30b4488832497e1681bd2125e04