### PR TITLE
Fix Electron 404 page

### DIFF
--- a/launcher-gui/src/App.tsx
+++ b/launcher-gui/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import { LauncherHeader } from "@/components/LauncherHeader";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
@@ -14,7 +14,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <HashRouter>
         <div className="min-h-screen bg-background">
           <LauncherHeader />
           <main>
@@ -25,7 +25,7 @@ const App = () => (
             </Routes>
           </main>
         </div>
-      </BrowserRouter>
+      </HashRouter>
     </TooltipProvider>
   </QueryClientProvider>
 );


### PR DESCRIPTION
## Summary
- use `HashRouter` in launcher GUI so routing works in electron

## Testing
- `pnpm lint` *(fails: 2129 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6871f35791748324a9aeb39d61ca3b9c