### PR TITLE
Enable window drag on launcher header

### DIFF
--- a/launcher-gui/src/components/LauncherHeader.tsx
+++ b/launcher-gui/src/components/LauncherHeader.tsx
@@ -7,7 +7,7 @@ import { SettingsModal } from "./SettingsModal";
 export function LauncherHeader() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   return (
-    <header className="border-b border-border mining-surface">
+    <header className="border-b border-border mining-surface drag-region">
       <div className="container mx-auto p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">

--- a/launcher-gui/src/components/Navigation.tsx
+++ b/launcher-gui/src/components/Navigation.tsx
@@ -19,7 +19,7 @@ export function Navigation({ onSettingsClick }: NavigationProps) {
   ];
 
   return (
-    <nav className="flex items-center justify-between w-full">
+    <nav className="flex items-center justify-between w-full no-drag">
       <div className="flex items-center gap-1">
         {navItems.map((item) => (
           <NavLink

--- a/launcher-gui/src/index.css
+++ b/launcher-gui/src/index.css
@@ -164,3 +164,13 @@ All colors MUST be HSL.
     box-shadow: 0 0 40px hsl(120 90% 60% / 0.8);
   }
 }
+
+@layer utilities {
+  .drag-region {
+    -webkit-app-region: drag;
+  }
+
+  .no-drag {
+    -webkit-app-region: no-drag;
+  }
+}


### PR DESCRIPTION
## Summary
- allow dragging the header area by adding a drag region class
- exclude navigation from drag handling

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_6871f410d0fc8324aa65fd2f654201c8