### PR TITLE
Fix header position

### DIFF
--- a/launcher-gui/src/components/LauncherHeader.tsx
+++ b/launcher-gui/src/components/LauncherHeader.tsx
@@ -7,7 +7,7 @@ import { SettingsModal } from './SettingsModal';
 export function LauncherHeader() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   return (
-    <header className="border-b border-border mining-surface drag-region">
+    <header className="sticky top-0 z-50 border-b border-border mining-surface drag-region">
       <div className="container mx-auto p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- keep the launcher header visible by using `sticky` positioning

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68722786e9e08324b3b9f3c9743fb135