### PR TITLE
Fix progress bar exceeding 100% when unpacking

### DIFF
--- a/launcher-gui/src/components/DownloadProgress.tsx
+++ b/launcher-gui/src/components/DownloadProgress.tsx
@@ -38,7 +38,7 @@ export function DownloadProgress({
 
   useEffect(() => {
     if (externalProgress !== undefined) {
-      setProgress(externalProgress);
+      setProgress(Math.min(externalProgress, 100));
       setDownloadSpeed(externalSpeed);
       setEta(externalEta);
       if (externalProgress >= 100) {

--- a/src/functions/unpackVersion.ts
+++ b/src/functions/unpackVersion.ts
@@ -55,7 +55,8 @@ export const unpackVersion = async ({
         if (updateStatus) {
           updateStatus({
             status: status.status,
-            progress: 60 + (status.progress ?? 0) * 0.95,
+            // Scale extraction progress to fit within the final 40% of overall progress
+            progress: 60 + (status.progress ?? 0) * 0.4,
           });
         }
       },


### PR DESCRIPTION
## Summary
- scale unpacking progress so it ends at 100%
- clamp reported download progress in the UI

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68722a2d7fc0832492cacc4bd89794b8