### PR TITLE
Add version maintenance features

### DIFF
--- a/src/functions/reinstallVersion.ts
+++ b/src/functions/reinstallVersion.ts
@@ -1,0 +1,41 @@
+import { deleteVersion } from './deleteVersion';
+import { downloadVersion } from './downloadVersion';
+import { unpackVersion } from './unpackVersion';
+
+export const reinstallVersion = async ({
+  versionIdentifier,
+  downloadPath,
+  updateStatus,
+}: {
+  versionIdentifier: string;
+  downloadPath: string;
+  updateStatus: (status: import('../types/ipcMessages').ProgressStatus) => void;
+}): Promise<{ reinstalled: boolean; message: string }> => {
+  const deleteResult = await deleteVersion({ versionIdentifier });
+  if (!deleteResult.deleted) {
+    return { reinstalled: false, message: deleteResult.message };
+  }
+
+  const downloadResult = await downloadVersion({
+    versionIdentifier,
+    downloadPath,
+    updateStatus,
+  });
+
+  if (!downloadResult.downloaded) {
+    return { reinstalled: false, message: downloadResult.message };
+  }
+
+  const unpackResult = await unpackVersion({
+    versionIdentifier,
+    installationDirectory: downloadPath,
+    updateStatus,
+    overwriteExisting: true,
+  });
+
+  if (!unpackResult.unpacked) {
+    return { reinstalled: false, message: unpackResult.message };
+  }
+
+  return { reinstalled: true, message: unpackResult.message };
+};

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -20,4 +20,5 @@ export const IPC_CHANNELS = {
   WINDOW_EXIT: 'window-exit',
   VERIFY_VERSION: 'verify-version',
   DELETE_VERSION: 'delete-version',
+  REINSTALL_VERSION: 'reinstall-version',
 } as const;

--- a/src/main/ipcHandlers/setupMaintenanceHandlers.ts
+++ b/src/main/ipcHandlers/setupMaintenanceHandlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { deleteVersion } from '../../functions/deleteVersion';
 import { verifyVersion } from '../../functions/verifyVersion';
+import { reinstallVersion } from '../../functions/reinstallVersion';
 import { IPC_CHANNELS } from './ipcChannels';
 import { withIpcHandler } from './withIpcHandler';
 
@@ -19,6 +20,20 @@ export const setupMaintenanceHandlers = async (): Promise<{ status: boolean; mes
       IPC_CHANNELS.VERIFY_VERSION,
       withIpcHandler(IPC_CHANNELS.VERIFY_VERSION, async (_event, versionIdentifier: string) => {
         return await verifyVersion({ versionIdentifier });
+      })
+    );
+
+    ipcMain.on(
+      IPC_CHANNELS.REINSTALL_VERSION,
+      withIpcHandler(IPC_CHANNELS.REINSTALL_VERSION, async (event, { version, downloadPath }) => {
+        const result = await reinstallVersion({
+          versionIdentifier: version,
+          downloadPath,
+          updateStatus: (statusObj: import('../../types/ipcMessages').ProgressStatus) => {
+            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, statusObj);
+          },
+        });
+        return result;
       })
     );
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -18,6 +18,7 @@ const validSendChannels: IpcChannel[] = [
   IPC_CHANNELS.OPEN_DIRECTORY_DIALOG,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REINSTALL_VERSION,
 ];
 
 const validReceiveChannels: IpcChannel[] = [
@@ -33,6 +34,7 @@ const validReceiveChannels: IpcChannel[] = [
   IPC_CHANNELS.SET_SETTINGS,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REINSTALL_VERSION,
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/assets/index-C9ASjlHD.js
+++ b/src/renderer/assets/index-C9ASjlHD.js
@@ -18927,11 +18927,14 @@ function aM() {
           : (console.log('Installing game version:', f.version), a(h => new Set([...h, f.version]))));
     },
     g = () => {
-      f && console.log('Verifying game version:', f.version);
+      f &&
+        (console.log('Verifying game version:', f.version),
+        window.electronAPI.send('verify-version', f.version));
     },
     w = () => {
       f &&
         (console.log('Deleting game version:', f.version),
+        window.electronAPI.send('delete-version', f.version),
         a(h => {
           const y = new Set(h);
           return (y.delete(f.version), y);
@@ -18940,6 +18943,7 @@ function aM() {
     x = () => {
       f &&
         (console.log('Reinstalling game version:', f.version),
+        window.electronAPI.send('reinstall-version', f.version),
         a(h => {
           const y = new Set(h);
           return (y.delete(f.version), y);


### PR DESCRIPTION
## Summary
- support reinstalling versions in main process
- expose new reinstall IPC channel in preload
- send verify/delete/reinstall actions from UI

## Testing
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68723c5011c083249edda04e5f973ecd