### PR TITLE
Add scripts to toggle launcher-gui Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "publish": "electron-forge publish",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"launcher-gui/src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
-    "generate:assets": "ts-node scripts/generateAssets.ts"
+    "generate:assets": "ts-node scripts/generateAssets.ts",
+    "hide-gui-git": "mv launcher-gui/.git launcher-gui/.git_hidden",
+    "restore-gui-git": "mv launcher-gui/.git_hidden launcher-gui/.git"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.1",


### PR DESCRIPTION
## Summary
- add `hide-gui-git` and `restore-gui-git` scripts in **package.json** to rename the `launcher-gui` submodule Git directory

## Testing
- `pnpm install`
- `pnpm run lint` *(fails: No files matching the pattern "launcher-gui/src/**/*.{ts,tsx}")*

------
https://chatgpt.com/codex/tasks/task_b_6872eea3fe948324b55948cd5756c7e2