### PR TITLE
Add version maintenance features

### DIFF
--- a/src/functions/deleteVersion.ts
+++ b/src/functions/deleteVersion.ts
@@ -4,16 +4,21 @@ import { getDirectories } from './fetchDirectories';
 
 export const deleteVersion = async ({
   versionIdentifier,
+  updateStatus,
 }: {
   versionIdentifier: string;
+  updateStatus?: (status: import('../types/ipcMessages').ProgressStatus) => void;
 }): Promise<{ deleted: boolean; message: string }> => {
   try {
+    updateStatus?.({ status: 'Removing old files...', progress: 5 });
     const { directories } = await getDirectories();
     const dirPath = path.join(directories.launcherInstallPath, versionIdentifier);
     await fs.rm(dirPath, { recursive: true, force: true });
+    updateStatus?.({ status: 'Files removed', progress: 10 });
     return { deleted: true, message: `Deleted ${dirPath}` };
   } catch (error: unknown) {
     const err = error as Error;
+    updateStatus?.({ status: err.message, progress: 10 });
     return { deleted: false, message: `Failed to delete version: ${err.message}` };
   }
 };

--- a/src/functions/reinstallVersion.ts
+++ b/src/functions/reinstallVersion.ts
@@ -1,0 +1,45 @@
+import { deleteVersion } from './deleteVersion';
+import { downloadVersion } from './downloadVersion';
+import { unpackVersion } from './unpackVersion';
+
+export const reinstallVersion = async ({
+  versionIdentifier,
+  downloadPath,
+  updateStatus,
+}: {
+  versionIdentifier: string;
+  downloadPath: string;
+  updateStatus: (status: import('../types/ipcMessages').ProgressStatus) => void;
+}): Promise<{ reinstalled: boolean; message: string }> => {
+  updateStatus({ status: 'Starting reinstall...', progress: 0 });
+  const deleteResult = await deleteVersion({
+    versionIdentifier,
+    updateStatus: status => updateStatus(status),
+  });
+  if (!deleteResult.deleted) {
+    return { reinstalled: false, message: deleteResult.message };
+  }
+
+  const downloadResult = await downloadVersion({
+    versionIdentifier,
+    downloadPath,
+    updateStatus,
+  });
+
+  if (!downloadResult.downloaded) {
+    return { reinstalled: false, message: downloadResult.message };
+  }
+
+  const unpackResult = await unpackVersion({
+    versionIdentifier,
+    installationDirectory: downloadPath,
+    updateStatus,
+    overwriteExisting: true,
+  });
+
+  if (!unpackResult.unpacked) {
+    return { reinstalled: false, message: unpackResult.message };
+  }
+
+  return { reinstalled: true, message: unpackResult.message };
+};

--- a/src/functions/verifyVersion.ts
+++ b/src/functions/verifyVersion.ts
@@ -2,14 +2,20 @@ import { isVersionInstalled } from './isVersionInstalled';
 
 export const verifyVersion = async ({
   versionIdentifier,
+  updateStatus,
 }: {
   versionIdentifier: string;
+  updateStatus?: (status: import('../types/ipcMessages').ProgressStatus) => void;
 }): Promise<{ verified: boolean; message: string }> => {
   try {
+    updateStatus?.({ status: 'Verifying installation...', progress: 5 });
     const installed = await isVersionInstalled(versionIdentifier);
-    return { verified: installed, message: installed ? 'Version verified' : 'Version not installed' };
+    const message = installed ? 'Version verified' : 'Version not installed';
+    updateStatus?.({ status: message, progress: 10 });
+    return { verified: installed, message };
   } catch (error: unknown) {
     const err = error as Error;
+    updateStatus?.({ status: err.message, progress: 10 });
     return { verified: false, message: `Verification failed: ${err.message}` };
   }
 };

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -20,4 +20,5 @@ export const IPC_CHANNELS = {
   WINDOW_EXIT: 'window-exit',
   VERIFY_VERSION: 'verify-version',
   DELETE_VERSION: 'delete-version',
+  REINSTALL_VERSION: 'reinstall-version',
 } as const;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -18,6 +18,7 @@ const validSendChannels: IpcChannel[] = [
   IPC_CHANNELS.OPEN_DIRECTORY_DIALOG,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REINSTALL_VERSION,
 ];
 
 const validReceiveChannels: IpcChannel[] = [
@@ -33,6 +34,7 @@ const validReceiveChannels: IpcChannel[] = [
   IPC_CHANNELS.SET_SETTINGS,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REINSTALL_VERSION,
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/assets/index-C9ASjlHD.js
+++ b/src/renderer/assets/index-C9ASjlHD.js
@@ -18927,11 +18927,14 @@ function aM() {
           : (console.log('Installing game version:', f.version), a(h => new Set([...h, f.version]))));
     },
     g = () => {
-      f && console.log('Verifying game version:', f.version);
+      f &&
+        (console.log('Verifying game version:', f.version),
+        window.electronAPI.send('verify-version', f.version));
     },
     w = () => {
       f &&
         (console.log('Deleting game version:', f.version),
+        window.electronAPI.send('delete-version', f.version),
         a(h => {
           const y = new Set(h);
           return (y.delete(f.version), y);
@@ -18940,6 +18943,7 @@ function aM() {
     x = () => {
       f &&
         (console.log('Reinstalling game version:', f.version),
+        window.electronAPI.send('reinstall-version', f.version),
         a(h => {
           const y = new Set(h);
           return (y.delete(f.version), y);


### PR DESCRIPTION
## Summary
- support reinstalling versions in main process
- expose new reinstall IPC channel in preload
- send verify/delete/reinstall actions from UI
- refine version maintenance operations

## Testing
- `pnpm lint` *(fails: No files matching the pattern "launcher-gui/src/**/*.{ts,tsx}" were found)*

------
https://chatgpt.com/codex/tasks/task_b_68723c5011c083249edda04e5f973ecd