### PR TITLE
Handle zip cleanup in maintenance tasks

### DIFF
--- a/src/functions/deleteVersion.ts
+++ b/src/functions/deleteVersion.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getDirectories } from './fetchDirectories';
+import { fetchVersions } from '../api/fetchVersions';
 
 export const deleteVersion = async ({
   versionIdentifier,
@@ -11,7 +12,21 @@ export const deleteVersion = async ({
     const { directories } = await getDirectories();
     const dirPath = path.join(directories.launcherInstallPath, versionIdentifier);
     await fs.rm(dirPath, { recursive: true, force: true });
-    return { deleted: true, message: `Deleted ${dirPath}` };
+
+    let zipMessage = '';
+    try {
+      const { versions } = await fetchVersions({ versionType: 'archived' });
+      const info = versions.find(v => v.identifier === versionIdentifier);
+      if (info) {
+        const zipPath = path.join(directories.launcherCachePath, info.filename);
+        await fs.rm(zipPath, { force: true });
+        zipMessage = ` and ${zipPath}`;
+      }
+    } catch {
+      // ignore if version info cannot be fetched or file cannot be removed
+    }
+
+    return { deleted: true, message: `Deleted ${dirPath}${zipMessage}` };
   } catch (error: unknown) {
     const err = error as Error;
     return { deleted: false, message: `Failed to delete version: ${err.message}` };

--- a/src/functions/reinstallVersion.ts
+++ b/src/functions/reinstallVersion.ts
@@ -1,0 +1,43 @@
+import { downloadVersion } from './downloadVersion';
+import { unpackVersion } from './unpackVersion';
+import { deleteVersion } from './deleteVersion';
+import { getDirectories } from './fetchDirectories';
+
+export const reinstallVersion = async ({
+  versionIdentifier,
+  updateStatus,
+}: {
+  versionIdentifier: string;
+  updateStatus?: (status: import('../types/ipcMessages').ProgressStatus) => void;
+}): Promise<{ reinstalled: boolean; message: string }> => {
+  try {
+    await deleteVersion({ versionIdentifier });
+
+    const { directories } = await getDirectories();
+
+    const downloadResult = await downloadVersion({
+      versionIdentifier,
+      downloadPath: directories.launcherCachePath,
+      updateStatus,
+    });
+    if (!downloadResult.downloaded) {
+      return { reinstalled: false, message: downloadResult.message };
+    }
+
+    const unpackResult = await unpackVersion({
+      versionIdentifier,
+      installationDirectory: directories.launcherInstallPath,
+      updateStatus,
+      overwriteExisting: true,
+    });
+
+    if (!unpackResult.unpacked) {
+      return { reinstalled: false, message: unpackResult.message };
+    }
+
+    return { reinstalled: true, message: unpackResult.message };
+  } catch (error: unknown) {
+    const err = error as Error;
+    return { reinstalled: false, message: `Reinstall failed: ${err.message}` };
+  }
+};

--- a/src/functions/verifyVersion.ts
+++ b/src/functions/verifyVersion.ts
@@ -1,4 +1,8 @@
+import path from 'path';
 import { isVersionInstalled } from './isVersionInstalled';
+import { getDirectories } from './fetchDirectories';
+import { fetchVersions } from '../api/fetchVersions';
+import { verifyFile } from '../fileUtils/fileOps';
 
 export const verifyVersion = async ({
   versionIdentifier,
@@ -6,8 +10,28 @@ export const verifyVersion = async ({
   versionIdentifier: string;
 }): Promise<{ verified: boolean; message: string }> => {
   try {
+    const directoriesResult = await getDirectories();
+    if (!directoriesResult.status || !directoriesResult.directories) {
+      throw new Error(directoriesResult.message);
+    }
+    const { launcherCachePath } = directoriesResult.directories;
+
+    const { versions } = await fetchVersions({ versionType: 'archived' });
+    const versionInfo = versions.find(v => v.identifier === versionIdentifier);
+    if (!versionInfo) {
+      throw new Error(`Version info not found for ${versionIdentifier}`);
+    }
+
+    const zipFilePath = path.join(launcherCachePath, versionInfo.filename);
+    const zipDetails = await verifyFile({ filePath: zipFilePath, expectedSize: versionInfo.sizeInBytes });
+
     const installed = await isVersionInstalled(versionIdentifier);
-    return { verified: installed, message: installed ? 'Version verified' : 'Version not installed' };
+
+    const installMessage = installed ? 'Installation found.' : 'Installation not found.';
+    const zipMessage = zipDetails.exists ? (zipDetails.sizeMatches ? 'Zip verified.' : 'Zip size mismatch.') : 'Zip missing.';
+
+    const verified = installed && zipDetails.exists && zipDetails.sizeMatches;
+    return { verified, message: `${installMessage} ${zipMessage}` };
   } catch (error: unknown) {
     const err = error as Error;
     return { verified: false, message: `Verification failed: ${err.message}` };

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -20,4 +20,5 @@ export const IPC_CHANNELS = {
   WINDOW_EXIT: 'window-exit',
   VERIFY_VERSION: 'verify-version',
   DELETE_VERSION: 'delete-version',
+  REINSTALL_VERSION: 'reinstall-version',
 } as const;

--- a/src/main/ipcHandlers/setupMaintenanceHandlers.ts
+++ b/src/main/ipcHandlers/setupMaintenanceHandlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { deleteVersion } from '../../functions/deleteVersion';
 import { verifyVersion } from '../../functions/verifyVersion';
+import { reinstallVersion } from '../../functions/reinstallVersion';
 import { IPC_CHANNELS } from './ipcChannels';
 import { withIpcHandler } from './withIpcHandler';
 
@@ -19,6 +20,18 @@ export const setupMaintenanceHandlers = async (): Promise<{ status: boolean; mes
       IPC_CHANNELS.VERIFY_VERSION,
       withIpcHandler(IPC_CHANNELS.VERIFY_VERSION, async (_event, versionIdentifier: string) => {
         return await verifyVersion({ versionIdentifier });
+      })
+    );
+
+    ipcMain.on(
+      IPC_CHANNELS.REINSTALL_VERSION,
+      withIpcHandler(IPC_CHANNELS.REINSTALL_VERSION, async (event, versionIdentifier: string) => {
+        return await reinstallVersion({
+          versionIdentifier,
+          updateStatus: statusObj => {
+            event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, statusObj);
+          },
+        });
       })
     );
 


### PR DESCRIPTION
## Summary
- include cache zip removal in deleteVersion
- verify the cached archive along with install directory
- add reinstallVersion helper and IPC hook

## Testing
- `npx --yes pnpm lint` *(fails: prettier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_6873035a40a4832481dea87ee48ea0fc