### PR TITLE
Add repair feature replacing reinstall

### DIFF
--- a/launcher-gui/src/components/GameNotifications.tsx
+++ b/launcher-gui/src/components/GameNotifications.tsx
@@ -6,7 +6,7 @@ import { Progress } from '@/components/ui/progress';
 
 export interface NotificationData {
   id: string;
-  type: 'download' | 'verify' | 'reinstall' | 'delete';
+  type: 'download' | 'verify' | 'repair' | 'delete';
   title: string;
   fileName?: string;
   fileSize?: string;
@@ -31,7 +31,7 @@ export function GameNotifications({ notifications, onDismiss }: GameNotification
       case 'verify':
         if (progress >= 100) return <CheckCircle className="w-5 h-5 text-primary" />;
         return <Shield className="w-5 h-5 text-primary animate-pulse" />;
-      case 'reinstall':
+      case 'repair':
         if (progress >= 100) return <CheckCircle className="w-5 h-5 text-primary" />;
         return <RotateCcw className="w-5 h-5 text-primary animate-spin" />;
       case 'delete':

--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -52,10 +52,10 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
   const [verifyProgress, setVerifyProgress] = useState(0);
   const [verifyStatus, setVerifyStatus] = useState('');
 
-  // Reinstall states  
-  const [isReinstalling, setIsReinstalling] = useState(false);
-  const [reinstallProgress, setReinstallProgress] = useState(0);
-  const [reinstallStatus, setReinstallStatus] = useState('');
+  // Repair states
+  const [isRepairing, setIsRepairing] = useState(false);
+  const [repairProgress, setRepairProgress] = useState(0);
+  const [repairStatus, setRepairStatus] = useState('');
 
   // Delete states
   const [isDeleting, setIsDeleting] = useState(false);
@@ -218,14 +218,14 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
       });
     }
 
-    if (isReinstalling) {
+    if (isRepairing) {
       notifications.push({
-        id: 'reinstall',
-        type: 'reinstall',
-        title: 'Game Reinstall',
+        id: 'repair',
+        type: 'repair',
+        title: 'Game Repair',
         fileName: selectedVersionData?.filename || 'ManicMiners2020-05-09.zip',
-        progress: reinstallProgress,
-        status: reinstallStatus,
+        progress: repairProgress,
+        status: repairStatus,
         isActive: true
       });
     }
@@ -245,7 +245,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
     onNotificationUpdate(notifications);
   }, [isDownloading, downloadProgress, downloadFileName, downloadTotalSize, downloadSpeed, downloadEta, downloadStatus,
       isVerifying, verifyProgress, verifyStatus,
-      isReinstalling, reinstallProgress, reinstallStatus,
+      isRepairing, repairProgress, repairStatus,
       isDeleting, deleteProgress, deleteStatus,
       selectedVersionData?.filename, onNotificationUpdate]);
 
@@ -303,31 +303,26 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
     });
   };
 
-  const handleReinstall = async () => {
-    if (!selectedVersionData) return;
-    setIsReinstalling(true);
-    setReinstallProgress(0);
-    setReinstallStatus('Removing existing installation...');
-    
-    // Simulate reinstall progress
-    const reinstallInterval = setInterval(() => {
-      setReinstallProgress(prev => {
+  const handleRepair = async () => {
+    if (!selectedVersionData || !window.electronAPI) return;
+    setIsRepairing(true);
+    setRepairProgress(0);
+    setRepairStatus('Checking files...');
+
+    window.electronAPI.send('repair-version', selectedVersionData.identifier);
+
+    const repairInterval = setInterval(() => {
+      setRepairProgress(prev => {
         const newProgress = prev + Math.random() * 10;
-        if (newProgress >= 50 && newProgress < 60) {
-          setReinstallStatus('Starting fresh download...');
-        }
         if (newProgress >= 100) {
-          clearInterval(reinstallInterval);
-          setReinstallStatus('Reinstallation completed successfully!');
-          setTimeout(() => setIsReinstalling(false), 2000);
+          clearInterval(repairInterval);
+          setRepairStatus('Repair completed successfully!');
+          setTimeout(() => setIsRepairing(false), 2000);
           return 100;
         }
         return newProgress;
       });
     }, 400);
-    
-    handleDelete();
-    setTimeout(() => handleInstallOrLaunch(), 100);
   };
 
 
@@ -374,7 +369,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
             onInstallOrLaunch={handleInstallOrLaunch}
             onVerify={handleVerify}
             onDelete={handleDelete}
-            onReinstall={handleReinstall}
+            onRepair={handleRepair}
           />
         </CardContent>
       </Card>

--- a/launcher-gui/src/components/VersionActions.tsx
+++ b/launcher-gui/src/components/VersionActions.tsx
@@ -28,17 +28,10 @@ interface VersionActionsProps {
   onInstallOrLaunch: () => void;
   onVerify: () => void;
   onDelete: () => void;
-  onReinstall: () => void;
+  onRepair: () => void;
 }
 
-export function VersionActions({ 
-  version, 
-  isInstalled, 
-  onInstallOrLaunch, 
-  onVerify, 
-  onDelete, 
-  onReinstall 
-}: VersionActionsProps) {
+export function VersionActions({ version, isInstalled, onInstallOrLaunch, onVerify, onDelete, onRepair }: VersionActionsProps) {
   if (!version) return null;
 
   return (
@@ -69,9 +62,9 @@ export function VersionActions({
               <Shield className="w-4 h-4" />
               Verify Files
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={onReinstall} className="flex items-center gap-2">
+            <DropdownMenuItem onClick={onRepair} className="flex items-center gap-2">
               <RotateCcw className="w-4 h-4" />
-              Reinstall
+              Repair
             </DropdownMenuItem>
             <DropdownMenuItem onClick={onDelete} className="flex items-center gap-2 text-destructive">
               <Trash2 className="w-4 h-4" />

--- a/src/functions/repairVersion.ts
+++ b/src/functions/repairVersion.ts
@@ -1,0 +1,68 @@
+import fs from 'fs/promises';
+import path from 'path';
+import StreamZip from 'node-stream-zip';
+import { fetchVersions } from '../api/fetchVersions';
+import { getDirectories } from './fetchDirectories';
+import { downloadVersion } from './downloadVersion';
+
+export const repairVersion = async ({
+  versionIdentifier,
+  updateStatus,
+}: {
+  versionIdentifier: string;
+  updateStatus?: (status: import('../types/ipcMessages').ProgressStatus) => void;
+}): Promise<{ repaired: boolean; message: string }> => {
+  try {
+    const { directories } = await getDirectories();
+
+    const downloadResult = await downloadVersion({
+      versionIdentifier,
+      downloadPath: directories.launcherCachePath,
+      updateStatus: status => updateStatus?.(status),
+    });
+    if (!downloadResult.downloaded) {
+      return { repaired: false, message: downloadResult.message };
+    }
+
+    const { versions } = await fetchVersions({ versionType: 'archived' });
+    const info = versions.find(v => v.identifier === versionIdentifier);
+    if (!info) {
+      throw new Error(`Version info not found for ${versionIdentifier}`);
+    }
+
+    const zipPath = path.join(directories.launcherCachePath, info.filename);
+    const installDir = path.join(directories.launcherInstallPath, versionIdentifier);
+
+    const zip = new StreamZip.async({ file: zipPath });
+    const entries = (await zip.entries()) as Record<string, StreamZip.ZipEntry>;
+    const totalEntries = Object.keys(entries).length || 1;
+    let processed = 0;
+
+    for (const entry of Object.values(entries)) {
+      const target = path.join(installDir, entry.name);
+      if (entry.isDirectory) {
+        await fs.mkdir(target, { recursive: true });
+      } else {
+        let needsRepair = false;
+        try {
+          const stat = await fs.stat(target);
+          if (stat.size !== entry.size) needsRepair = true;
+        } catch {
+          needsRepair = true;
+        }
+        if (needsRepair) {
+          await fs.mkdir(path.dirname(target), { recursive: true });
+          await zip.extract(entry.name, target);
+        }
+      }
+      processed++;
+      updateStatus?.({ status: 'Repairing files...', progress: (processed / totalEntries) * 100 });
+    }
+
+    await zip.close();
+    return { repaired: true, message: 'Repair completed' };
+  } catch (error: unknown) {
+    const err = error as Error;
+    return { repaired: false, message: `Repair failed: ${err.message}` };
+  }
+};

--- a/src/main/ipcHandlers/ipcChannels.ts
+++ b/src/main/ipcHandlers/ipcChannels.ts
@@ -20,5 +20,5 @@ export const IPC_CHANNELS = {
   WINDOW_EXIT: 'window-exit',
   VERIFY_VERSION: 'verify-version',
   DELETE_VERSION: 'delete-version',
-  REINSTALL_VERSION: 'reinstall-version',
+  REPAIR_VERSION: 'repair-version',
 } as const;

--- a/src/main/ipcHandlers/setupMaintenanceHandlers.ts
+++ b/src/main/ipcHandlers/setupMaintenanceHandlers.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { deleteVersion } from '../../functions/deleteVersion';
 import { verifyVersion } from '../../functions/verifyVersion';
-import { reinstallVersion } from '../../functions/reinstallVersion';
+import { repairVersion } from '../../functions/repairVersion';
 import { IPC_CHANNELS } from './ipcChannels';
 import { withIpcHandler } from './withIpcHandler';
 
@@ -24,9 +24,9 @@ export const setupMaintenanceHandlers = async (): Promise<{ status: boolean; mes
     );
 
     ipcMain.on(
-      IPC_CHANNELS.REINSTALL_VERSION,
-      withIpcHandler(IPC_CHANNELS.REINSTALL_VERSION, async (event, versionIdentifier: string) => {
-        return await reinstallVersion({
+      IPC_CHANNELS.REPAIR_VERSION,
+      withIpcHandler(IPC_CHANNELS.REPAIR_VERSION, async (event, versionIdentifier: string) => {
+        return await repairVersion({
           versionIdentifier,
           updateStatus: statusObj => {
             event.sender.send(IPC_CHANNELS.DOWNLOAD_PROGRESS, statusObj);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -18,6 +18,7 @@ const validSendChannels: IpcChannel[] = [
   IPC_CHANNELS.OPEN_DIRECTORY_DIALOG,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REPAIR_VERSION,
 ];
 
 const validReceiveChannels: IpcChannel[] = [
@@ -33,6 +34,7 @@ const validReceiveChannels: IpcChannel[] = [
   IPC_CHANNELS.SET_SETTINGS,
   IPC_CHANNELS.VERIFY_VERSION,
   IPC_CHANNELS.DELETE_VERSION,
+  IPC_CHANNELS.REPAIR_VERSION,
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {


### PR DESCRIPTION
## Summary
- add `repairVersion` function to verify and restore game files
- switch IPC constant and handlers from reinstall to repair
- update preload channel allowlist
- update UI components to show Repair option and send new IPC message

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68730a13aabc83248fdf77a343098596