### PR TITLE
Remove Verify Files option

### DIFF
--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -367,7 +367,6 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
             version={selectedVersionData}
             isInstalled={selectedVersionData ? isVersionInstalled(selectedVersionData.version) : false}
             onInstallOrLaunch={handleInstallOrLaunch}
-            onVerify={handleVerify}
             onDelete={handleDelete}
             onRepair={handleRepair}
           />

--- a/launcher-gui/src/components/VersionActions.tsx
+++ b/launcher-gui/src/components/VersionActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { Play, Download, Menu, Shield, Trash2, RotateCcw } from 'lucide-react';
+import { Play, Download, Menu, Trash2, RotateCcw } from 'lucide-react';
 
 interface GameVersion {
   gameId: number;
@@ -26,12 +26,11 @@ interface VersionActionsProps {
   version: GameVersion | null;
   isInstalled: boolean;
   onInstallOrLaunch: () => void;
-  onVerify: () => void;
   onDelete: () => void;
   onRepair: () => void;
 }
 
-export function VersionActions({ version, isInstalled, onInstallOrLaunch, onVerify, onDelete, onRepair }: VersionActionsProps) {
+export function VersionActions({ version, isInstalled, onInstallOrLaunch, onDelete, onRepair }: VersionActionsProps) {
   if (!version) return null;
 
   return (
@@ -58,10 +57,6 @@ export function VersionActions({ version, isInstalled, onInstallOrLaunch, onVeri
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="mining-surface border-primary/20">
-            <DropdownMenuItem onClick={onVerify} className="flex items-center gap-2">
-              <Shield className="w-4 h-4" />
-              Verify Files
-            </DropdownMenuItem>
             <DropdownMenuItem onClick={onRepair} className="flex items-center gap-2">
               <RotateCcw className="w-4 h-4" />
               Repair


### PR DESCRIPTION
## Summary
- remove Verify Files dropdown from VersionActions menu
- drop unused onVerify prop

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_68731dd292c08324a7a71b638732d1a3