### PR TITLE
Disable buttons during active tasks

### DIFF
--- a/launcher-gui/src/components/VersionActions.tsx
+++ b/launcher-gui/src/components/VersionActions.tsx
@@ -28,14 +28,15 @@ interface VersionActionsProps {
   onInstallOrLaunch: () => void;
   onDelete: () => void;
   onRepair: () => void;
+  disabled?: boolean;
 }
 
-export function VersionActions({ version, isInstalled, onInstallOrLaunch, onDelete, onRepair }: VersionActionsProps) {
+export function VersionActions({ version, isInstalled, onInstallOrLaunch, onDelete, onRepair, disabled = false }: VersionActionsProps) {
   if (!version) return null;
 
   return (
     <div className="flex gap-2">
-      <Button variant="energy" className="flex-1" onClick={onInstallOrLaunch}>
+      <Button variant="energy" className="flex-1" onClick={onInstallOrLaunch} disabled={disabled}>
         {isInstalled ? (
           <>
             <Play className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- disable the install button while installing a game
- disable the launch button when repairing or deleting

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6873224893a08324adaddec3ddb96dce