### PR TITLE
Fix repair action in archived versions

### DIFF
--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -48,10 +48,10 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
   const [downloadEta, setDownloadEta] = useState('--:--');
 
 
-  // Reinstall states  
-  const [isReinstalling, setIsReinstalling] = useState(false);
-  const [reinstallProgress, setReinstallProgress] = useState(0);
-  const [reinstallStatus, setReinstallStatus] = useState('');
+  // Repair states
+  const [isRepairing, setIsRepairing] = useState(false);
+  const [repairProgress, setRepairProgress] = useState(0);
+  const [repairStatus, setRepairStatus] = useState('');
 
   // Delete states
   const [isDeleting, setIsDeleting] = useState(false);
@@ -203,14 +203,14 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
     }
 
 
-    if (isReinstalling) {
+    if (isRepairing) {
       notifications.push({
-        id: 'reinstall',
-        type: 'reinstall',
-        title: 'Game Reinstall',
+        id: 'repair',
+        type: 'repair',
+        title: 'Game Repair',
         fileName: selectedVersionData?.filename || 'ManicMiners2020-05-09.zip',
-        progress: reinstallProgress,
-        status: reinstallStatus,
+        progress: repairProgress,
+        status: repairStatus,
         isActive: true
       });
     }
@@ -229,7 +229,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
 
     onNotificationUpdate(notifications);
   }, [isDownloading, downloadProgress, downloadFileName, downloadTotalSize, downloadSpeed, downloadEta, downloadStatus,
-      isReinstalling, reinstallProgress, reinstallStatus,
+      isRepairing, repairProgress, repairStatus,
       isDeleting, deleteProgress, deleteStatus,
       selectedVersionData?.filename, onNotificationUpdate]);
 
@@ -266,31 +266,26 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
     });
   };
 
-  const handleReinstall = async () => {
-    if (!selectedVersionData) return;
-    setIsReinstalling(true);
-    setReinstallProgress(0);
-    setReinstallStatus('Removing existing installation...');
-    
-    // Simulate reinstall progress
-    const reinstallInterval = setInterval(() => {
-      setReinstallProgress(prev => {
+  const handleRepair = async () => {
+    if (!selectedVersionData || !window.electronAPI) return;
+    setIsRepairing(true);
+    setRepairProgress(0);
+    setRepairStatus('Checking files...');
+
+    window.electronAPI.send('repair-version', selectedVersionData.identifier);
+
+    const repairInterval = setInterval(() => {
+      setRepairProgress(prev => {
         const newProgress = prev + Math.random() * 10;
-        if (newProgress >= 50 && newProgress < 60) {
-          setReinstallStatus('Starting fresh download...');
-        }
         if (newProgress >= 100) {
-          clearInterval(reinstallInterval);
-          setReinstallStatus('Reinstallation completed successfully!');
-          setTimeout(() => setIsReinstalling(false), 2000);
+          clearInterval(repairInterval);
+          setRepairStatus('Repair completed successfully!');
+          setTimeout(() => setIsRepairing(false), 2000);
           return 100;
         }
         return newProgress;
       });
     }, 400);
-    
-    handleDelete();
-    setTimeout(() => handleInstallOrLaunch(), 100);
   };
 
 
@@ -402,7 +397,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
                   isInstalled={selectedVersionData ? isVersionInstalled(selectedVersionData.version) : false}
                   onInstallOrLaunch={handleInstallOrLaunch}
                   onDelete={handleDelete}
-                  onReinstall={handleReinstall}
+                  onRepair={handleRepair}
                 />
               </CardContent>
             </Card>

--- a/launcher-gui/src/components/VersionActions.tsx
+++ b/launcher-gui/src/components/VersionActions.tsx
@@ -27,15 +27,15 @@ interface VersionActionsProps {
   isInstalled: boolean;
   onInstallOrLaunch: () => void;
   onDelete: () => void;
-  onReinstall: () => void;
+  onRepair: () => void;
 }
 
-export function VersionActions({ 
-  version, 
-  isInstalled, 
-  onInstallOrLaunch, 
-  onDelete, 
-  onReinstall 
+export function VersionActions({
+  version,
+  isInstalled,
+  onInstallOrLaunch,
+  onDelete,
+  onRepair
 }: VersionActionsProps) {
   if (!version) return null;
 
@@ -63,7 +63,7 @@ export function VersionActions({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="mining-surface border-primary/20">
-            <DropdownMenuItem onClick={onReinstall} className="flex items-center gap-2">
+            <DropdownMenuItem onClick={onRepair} className="flex items-center gap-2">
               <RotateCcw className="w-4 h-4" />
               Repair
             </DropdownMenuItem>

--- a/launcher-gui/src/pages/GameVersions.tsx
+++ b/launcher-gui/src/pages/GameVersions.tsx
@@ -15,7 +15,7 @@ const GameVersions = () => {
 
   return (
     <div className="h-full flex flex-col overflow-y-auto relative">
-      <GameNotifications 
+      <GameNotifications
         notifications={notifications}
         onDismiss={handleDismissNotification}
       />


### PR DESCRIPTION
## Summary
- restore `onRepair` prop in `VersionActions` and menu item
- restore repair state logic in `GameVersionSelector`
- clean stray output from `GameVersions` page

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_6873425953c08324a7b08e7812625f65