### PR TITLE
Fix install button state and external footer links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -41,21 +41,27 @@ export function Footer() {
           {Object.entries(urls)
             .filter(([name]) => name !== 'FAQ' && name !== 'Email')
             .map(([name, url]) => {
-            const Icon = iconMap[name as keyof typeof iconMap];
-            return (
-              <a
-                key={name}
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"
-                title={name}
-              >
-                <Icon className="w-4 h-4" />
-                <span className="hidden sm:inline">{name}</span>
-              </a>
-            );
-          })}
+              const Icon = iconMap[name as keyof typeof iconMap];
+              return (
+                <a
+                  key={name}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={e => {
+                    if (window.electronAPI) {
+                      e.preventDefault();
+                      window.electronAPI.openExternal(url);
+                    }
+                  }}
+                  className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"
+                  title={name}
+                >
+                  <Icon className="w-4 h-4" />
+                  <span className="hidden sm:inline">{name}</span>
+                </a>
+              );
+            })}
           <Link
             to="/faq"
             className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"

--- a/launcher-gui/src/components/GameVersionSelector.tsx
+++ b/launcher-gui/src/components/GameVersionSelector.tsx
@@ -375,6 +375,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
                 onInstallOrLaunch={handleInstallOrLaunch}
                 onDelete={handleDelete}
                 onRepair={handleRepair}
+                isProcessing={isDownloading}
               />
             </CardContent>
           </Card>
@@ -422,6 +423,7 @@ export function GameVersionSelector({ onDownloadStart, onDownloadEnd, onNotifica
                 onInstallOrLaunch={handleInstallOrLaunch}
                 onDelete={handleDelete}
                 onRepair={handleRepair}
+                isProcessing={isDownloading}
               />
             </CardContent>
           </Card>

--- a/launcher-gui/src/components/VersionActions.tsx
+++ b/launcher-gui/src/components/VersionActions.tsx
@@ -28,6 +28,7 @@ interface VersionActionsProps {
   onInstallOrLaunch: () => void;
   onDelete: () => void;
   onRepair: () => void;
+  isProcessing?: boolean;
 }
 
 export function VersionActions({
@@ -35,13 +36,19 @@ export function VersionActions({
   isInstalled,
   onInstallOrLaunch,
   onDelete,
-  onRepair
+  onRepair,
+  isProcessing
 }: VersionActionsProps) {
   if (!version) return null;
 
   return (
     <div className="flex gap-2">
-      <Button variant="energy" className="flex-1" onClick={onInstallOrLaunch}>
+      <Button
+        variant="energy"
+        className="flex-1"
+        onClick={onInstallOrLaunch}
+        disabled={isProcessing}
+      >
         {isInstalled ? (
           <>
             <Play className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- disable install button on archived versions page while downloading
- open footer links in the user's default browser

## Testing
- `pnpm lint` *(fails: prettier errors in repo)*

------
https://chatgpt.com/codex/tasks/task_b_687350ef91a4832486bb0ba15a44d129