### PR TITLE
Use Manic Miners icon and app name

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,7 @@ import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
+import path from 'path';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
 import { WebpackPlugin } from '@electron-forge/plugin-webpack';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
@@ -14,9 +15,17 @@ import { rendererConfig } from './config/webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    icon: path.resolve(__dirname, 'assets', 'manic-miners-favicon'),
   },
   rebuildConfig: {},
-  makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],
+  makers: [
+    new MakerSquirrel({
+      setupIcon: path.resolve(__dirname, 'assets', 'manic-miners-favicon.ico'),
+    }),
+    new MakerZIP({}, ['darwin']),
+    new MakerRpm({}),
+    new MakerDeb({}),
+  ],
   plugins: [
     new AutoUnpackNativesPlugin({}),
     new WebpackPlugin({

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "manic-miners-launcher",
+  "productName": "Manic Miners Launcher",
   "version": "1.0.0",
   "description": "A dedicated launcher for Manic Miners, an adventurous underground mining game that pays homage to classic resource management and strategy games.",
   "main": ".webpack/main",

--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -17,6 +17,8 @@ export const createWindow = (): void => {
     },
     autoHideMenuBar: true, // This will hide the menu bar
     frame: false, // This will remove the frame
+    icon: path.join(__dirname, '../assets/manic-miners-favicon.ico'),
+    title: 'Manic Miners Launcher',
   });
 
   // Ensure the renderer starts on the Home page in both dev and prod.


### PR DESCRIPTION
## Summary
- add `productName` to package.json so the app is called **Manic Miners Launcher**
- point Forge's packager and Squirrel maker at `manic-miners-favicon` for the icon
- show the icon and title when creating the main window

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_687356b3c4c88324adea8250f8391197