### PR TITLE
Fix footer links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -1,16 +1,6 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Globe, MessageSquare, Users, Play, Facebook, HelpCircle, Mail } from 'lucide-react';
-
-interface UrlData {
-  Website: string;
-  Discord: string;
-  Reddit: string;
-  YouTube: string;
-  Facebook: string;
-  FAQ: string;
-  Email: string;
-}
+import { FOOTER_URLS } from '../lib/footerUrls';
 
 const iconMap = {
   Website: Globe,
@@ -23,16 +13,7 @@ const iconMap = {
 };
 
 export function Footer() {
-  const [urls, setUrls] = useState<UrlData | null>(null);
-
-  useEffect(() => {
-    fetch('https://manic-launcher.vercel.app/api/urls')
-      .then(response => response.json())
-      .then((data: UrlData) => setUrls(data))
-      .catch(error => console.error('Failed to fetch URLs:', error));
-  }, []);
-
-  if (!urls) return null;
+  const urls = FOOTER_URLS;
 
   return (
     <footer className="border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">

--- a/launcher-gui/src/lib/footerUrls.js
+++ b/launcher-gui/src/lib/footerUrls.js
@@ -1,0 +1,9 @@
+export const FOOTER_URLS = {
+  Website: 'https://manicminers.baraklava.com/',
+  Discord: 'https://discord.gg/C3hH7mFsMv',
+  Reddit: 'https://www.reddit.com/r/manicminers/',
+  YouTube: 'https://youtu.be/1mQacGNeNVA?list=PL2_YluKFsmfIAT4G9zlUmbmRuX4Kvb75g',
+  Facebook: 'https://www.facebook.com/ManicMinersGame/',
+  FAQ: 'https://manicminers.baraklava.com/faq/',
+  Email: 'mailto:rockraidersremake@gmail.com',
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "publish": "electron-forge publish",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"launcher-gui/src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
-    "generate:assets": "ts-node scripts/generateAssets.ts"
+    "generate:assets": "ts-node scripts/generateAssets.ts",
+    "test": "node --test"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.1",

--- a/tests/footerUrls.test.js
+++ b/tests/footerUrls.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import test from 'node:test';
+import { FOOTER_URLS } from '../launcher-gui/src/lib/footerUrls.js';
+
+const expectedKeys = [
+  'Website',
+  'Discord',
+  'Reddit',
+  'YouTube',
+  'Facebook',
+  'FAQ',
+  'Email',
+];
+
+test('FOOTER_URLS contains all expected links', () => {
+  for (const key of expectedKeys) {
+    assert.ok(key in FOOTER_URLS, `missing key: ${key}`);
+    const url = FOOTER_URLS[key];
+    assert.match(url, /^(https?:\/\/|mailto:)/, `invalid url for ${key}`);
+  }
+});


### PR DESCRIPTION
## Summary
- load footer URLs from a local constant instead of fetching
- add a simple test for the URLs

## Testing
- `npm test`
- `pnpm run lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_68736a3424d08324ab1b40a7947c1075