### PR TITLE
Fix footer external links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -30,9 +30,11 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={e => {
-                    if (window.electronAPI) {
-                      e.preventDefault();
+                    e.preventDefault();
+                    if (window.electronAPI?.openExternal) {
                       window.electronAPI.openExternal(url);
+                    } else {
+                      window.open(url, '_blank', 'noopener');
                     }
                   }}
                   className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"

--- a/launcher-gui/src/types/electron.d.ts
+++ b/launcher-gui/src/types/electron.d.ts
@@ -5,6 +5,7 @@ declare global {
       receive: (channel: string, func: (data: any) => void) => void;
       receiveOnce: (channel: string, func: (data: any) => void) => void;
       removeAllListeners: (channel: string) => void;
+      openExternal?: (url: string) => void;
     };
   }
 }


### PR DESCRIPTION
## Summary
- handle external link clicks with fallback to `window.open`
- add optional `openExternal` method to frontend Electron types

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_687370395b5c8324a5b83d4708387393