### PR TITLE
Fix footer links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -49,7 +49,7 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={e => {
-                    if (window.electronAPI) {
+                    if (window.electronAPI?.openExternal) {
                       e.preventDefault();
                       window.electronAPI.openExternal(url);
                     }

--- a/launcher-gui/src/types/electron.d.ts
+++ b/launcher-gui/src/types/electron.d.ts
@@ -5,6 +5,8 @@ declare global {
       receive: (channel: string, func: (data: any) => void) => void;
       receiveOnce: (channel: string, func: (data: any) => void) => void;
       removeAllListeners: (channel: string) => void;
+      openExternal: (url: string) => void;
+      platform: string;
     };
   }
 }


### PR DESCRIPTION
## Summary
- update electron types to include `openExternal`
- open external links only when Electron API is available

## Testing
- `pnpm lint` *(fails: prettier errors)*
- `pnpm tsc` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_687407186504832486f38106e9a8d0e3