### PR TITLE
Fix footer links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -49,9 +49,11 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={e => {
-                    if (window.electronAPI) {
+                    if (window.electronAPI?.openExternal) {
                       e.preventDefault();
                       window.electronAPI.openExternal(url);
+                    } else {
+                      window.open(url, '_blank');
                     }
                   }}
                   className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"

--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -49,8 +49,8 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={e => {
+                    e.preventDefault();
                     if (window.electronAPI?.openExternal) {
-                      e.preventDefault();
                       window.electronAPI.openExternal(url);
                     } else {
                       window.open(url, '_blank');

--- a/launcher-gui/src/types/electron.d.ts
+++ b/launcher-gui/src/types/electron.d.ts
@@ -5,6 +5,8 @@ declare global {
       receive: (channel: string, func: (data: any) => void) => void;
       receiveOnce: (channel: string, func: (data: any) => void) => void;
       removeAllListeners: (channel: string) => void;
+      openExternal: (url: string) => void;
+      platform: string;
     };
   }
 }


### PR DESCRIPTION
## Summary
- always fall back to `window.open` if the Electron API isn't available

## Testing
- `pnpm lint` *(fails: prettier errors in unrelated files)*
- `pnpm tsc` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_687407186504832486f38106e9a8d0e3