### PR TITLE
Fix footer links not opening in browser

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -49,11 +49,9 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={e => {
-                    e.preventDefault();
                     if (window.electronAPI?.openExternal) {
+                      e.preventDefault();
                       window.electronAPI.openExternal(url);
-                    } else {
-                      window.open(url, '_blank');
                     }
                   }}
                   className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"


### PR DESCRIPTION
## Summary
- open footer links normally when not running under Electron

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_68742e9078d88324bcf20e3daadd64ec