### PR TITLE
Open footer links with window.open

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -50,11 +50,7 @@ export function Footer() {
                   rel="noopener noreferrer"
                   onClick={e => {
                     e.preventDefault();
-                    if (window.electronAPI?.openExternal) {
-                      window.electronAPI.openExternal(url);
-                    } else {
-                      window.open(url, '_blank');
-                    }
+                    window.open(url, '_blank');
                   }}
                   className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"
                   title={name}


### PR DESCRIPTION
## Summary
- always open external footer links using `window.open`

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_68742e9078d88324bcf20e3daadd64ec