### PR TITLE
Fix external footer links

### DIFF
--- a/launcher-gui/src/components/Footer.tsx
+++ b/launcher-gui/src/components/Footer.tsx
@@ -50,7 +50,11 @@ export function Footer() {
                   rel="noopener noreferrer"
                   onClick={e => {
                     e.preventDefault();
-                    window.open(url, '_blank');
+                    if (window.electronAPI?.openExternal) {
+                      window.electronAPI.openExternal(url);
+                    } else {
+                      window.open(url, '_blank');
+                    }
                   }}
                   className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors text-sm"
                   title={name}

--- a/launcher-gui/src/pages/FAQ.tsx
+++ b/launcher-gui/src/pages/FAQ.tsx
@@ -75,7 +75,11 @@ const FAQ = () => {
                 <Button 
                   variant="link" 
                   className="p-0 h-auto text-muted-foreground underline"
-                  onClick={() => window.open('https://github.com/Wal33D/manic-miners-launcher', '_blank')}
+                  onClick={() =>
+                    window.electronAPI?.openExternal
+                      ? window.electronAPI.openExternal('https://github.com/Wal33D/manic-miners-launcher')
+                      : window.open('https://github.com/Wal33D/manic-miners-launcher', '_blank')
+                  }
                 >
                   GitHub
                 </Button>!
@@ -87,7 +91,11 @@ const FAQ = () => {
           <div className="flex justify-center">
             <Button 
               variant="outline" 
-              onClick={() => window.open('https://discord.gg/C3hH7mFsMv', '_blank')}
+              onClick={() =>
+                window.electronAPI?.openExternal
+                  ? window.electronAPI.openExternal('https://discord.gg/C3hH7mFsMv')
+                  : window.open('https://discord.gg/C3hH7mFsMv', '_blank')
+              }
             >
               <ExternalLink className="w-4 h-4 mr-2" />
               Join Discord
@@ -119,7 +127,11 @@ const FAQ = () => {
               </CardHeader>
               <CardContent className="p-6">
                 <Button 
-                  onClick={() => window.open('https://discord.gg/C3hH7mFsMv', '_blank')}
+                  onClick={() =>
+                    window.electronAPI?.openExternal
+                      ? window.electronAPI.openExternal('https://discord.gg/C3hH7mFsMv')
+                      : window.open('https://discord.gg/C3hH7mFsMv', '_blank')
+                  }
                   className="w-full"
                 >
                   <ExternalLink className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- call `window.electronAPI.openExternal` when clicking footer links
- do the same for FAQ page buttons

## Testing
- `pnpm lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_6874380258dc8324bd3e6e86c8cad500